### PR TITLE
Use Swift 3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ibmcom/swift-ubuntu:3.0.2
+FROM ibmcom/swift-ubuntu:3.1
 
 RUN \
   export DEBIAN_FRONTEND=noninteractive && \

--- a/Package.pins
+++ b/Package.pins
@@ -1,0 +1,84 @@
+{
+  "autoPin": true,
+  "pins": [
+    {
+      "package": "CCurl",
+      "reason": null,
+      "repositoryURL": "https://github.com/IBM-Swift/CCurl.git",
+      "version": "0.2.3"
+    },
+    {
+      "package": "HeliumLogger",
+      "reason": null,
+      "repositoryURL": "https://github.com/IBM-Swift/HeliumLogger.git",
+      "version": "1.6.1"
+    },
+    {
+      "package": "Kitura",
+      "reason": null,
+      "repositoryURL": "https://github.com/IBM-Swift/Kitura.git",
+      "version": "1.6.3"
+    },
+    {
+      "package": "Kitura-TemplateEngine",
+      "reason": null,
+      "repositoryURL": "https://github.com/IBM-Swift/Kitura-TemplateEngine.git",
+      "version": "1.6.0"
+    },
+    {
+      "package": "Kitura-net",
+      "reason": null,
+      "repositoryURL": "https://github.com/IBM-Swift/Kitura-net.git",
+      "version": "1.6.2"
+    },
+    {
+      "package": "KituraStencil",
+      "reason": null,
+      "repositoryURL": "https://github.com/IBM-Swift/Kitura-StencilTemplateEngine.git",
+      "version": "1.6.0"
+    },
+    {
+      "package": "LoggerAPI",
+      "reason": null,
+      "repositoryURL": "https://github.com/IBM-Swift/LoggerAPI.git",
+      "version": "1.6.0"
+    },
+    {
+      "package": "PathKit",
+      "reason": null,
+      "repositoryURL": "https://github.com/kylef/PathKit.git",
+      "version": "0.7.1"
+    },
+    {
+      "package": "SSLService",
+      "reason": null,
+      "repositoryURL": "https://github.com/IBM-Swift/BlueSSLService.git",
+      "version": "0.12.30"
+    },
+    {
+      "package": "Socket",
+      "reason": null,
+      "repositoryURL": "https://github.com/IBM-Swift/BlueSocket.git",
+      "version": "0.12.41"
+    },
+    {
+      "package": "Spectre",
+      "reason": null,
+      "repositoryURL": "https://github.com/kylef/Spectre",
+      "version": "0.7.2"
+    },
+    {
+      "package": "Stencil",
+      "reason": null,
+      "repositoryURL": "https://github.com/kylef/Stencil",
+      "version": "0.7.2"
+    },
+    {
+      "package": "SwiftyJSON",
+      "reason": null,
+      "repositoryURL": "https://github.com/IBM-Swift/SwiftyJSON.git",
+      "version": "15.0.6"
+    }
+  ],
+  "version": 1
+}


### PR DESCRIPTION
Swift 3.1 introduces a few small changes, including lockfiles (Package.pins) for Swift Package Manager. More info can be found at [https://swift.org/blog/swift-3-1-released/](https://swift.org/blog/swift-3-1-released/)