### PR TITLE
Fix node engine version to use 6.11.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ RUN \
   curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
   echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
   apt-get update && \
-  apt-get install nodejs yarn
+  apt-get install nodejs yarn && \
+  npm install -g n && \
+  n 6.11.3
 
 RUN yarn config set cache-folder /yarn_cache
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "heroku-postbuild": "gulp static-build"
   },
   "engines": {
-    "node": "6.10.0"
+    "node": "6.11.3"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
This PR fixes an issue which was preventing people from cloning the repo and starting up the server properly unless they had a docker image with a specific node version installed.
