### PR TITLE
Fix warning during `docker-compose build`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM ibmcom/swift-ubuntu:3.1
 
+# Allow installation of Node 6: https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions \
+# Install Yarn: https://yarnpkg.com/en/docs/install#linux-tab
+
 RUN \
   export DEBIAN_FRONTEND=noninteractive && \
   apt-get update && \
   apt-get install curl apt-transport-https && \
-  # Allow installation of Node 6: https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions \
   curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash - && \
-  # Install Yarn: https://yarnpkg.com/en/docs/install#linux-tab
   curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
   echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
   apt-get update && \


### PR DESCRIPTION
```bash
[WARNING]: Empty continuation line found in:
    RUN   export DEBIAN_FRONTEND=noninteractive &&   apt-get update &&   apt-get install curl apt-transport-https &&   curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash - &&   curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - &&   echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list &&   apt-get update &&   apt-get install nodejs yarn &&   npm install -g n &&   n 6.11.3
[WARNING]: Empty continuation lines will become errors in a future release.
```