### PR TITLE
Add generic redirects middleware + intro redirect

### DIFF
--- a/Sources/HaCWebsiteLib/Controllers/RedirectsMiddleware.swift
+++ b/Sources/HaCWebsiteLib/Controllers/RedirectsMiddleware.swift
@@ -1,0 +1,34 @@
+import Kitura
+
+private struct Redirect {
+  let fromPath: String
+  let toURL: String
+}
+
+private let defaultRedirects = [
+  Redirect(
+    fromPath: "/intro-to-programming",
+    toURL: "https://github.com/hackersatcambridge/workshops/blob/master/workshops/introduction_to_programming/session_1/description.md"
+  )
+]
+
+private func redirectRouter(_ redirects: [Redirect]) -> Router {
+  let router = Router()
+
+  for redirect in redirects {
+    router.get(redirect.fromPath) { _, response, next in
+      try response.redirect(redirect.toURL, status: .movedTemporarily).end()
+      next()
+    }
+  }
+
+  return router
+}
+
+private let router = redirectRouter(defaultRedirects)
+
+struct RedirectsMiddleware: RouterMiddleware {
+   func handle(request: RouterRequest, response: RouterResponse, next: @escaping () -> Void) throws -> () {
+     try router.handle(request: request, response: response, next: next)
+  }
+}

--- a/Sources/HaCWebsiteLib/routes.swift
+++ b/Sources/HaCWebsiteLib/routes.swift
@@ -20,6 +20,7 @@ func getWebsiteRouter() -> Router {
   }
 
   router.all("/static", middleware: StaticFileServer(path: "./static/dist"))
+  router.all("/", middleware: RedirectsMiddleware())
   router.all("/", middleware: NotFoundHandler())
 
   /// Intended for use by GitHub webhooks


### PR DESCRIPTION
This gives us the ability to make a list of static redirects from paths to arbitrary URL strings.

Included is a redirect to our "Intro to programming" workshop.
