### PR TITLE
Label events 'live now' when appropriate

### DIFF
--- a/Sources/HaCWebsiteLib/ViewModels/LandingPage/EventFeature.swift
+++ b/Sources/HaCWebsiteLib/ViewModels/LandingPage/EventFeature.swift
@@ -27,9 +27,16 @@ struct EventFeature: LandingFeature {
   }
 
   var dateBlock: Nodeable {
-    return El.Div[Attr.className => "EventFeature__date"].containing(
-      DateUtils.individualDayFormatter.string(from: eventPeriod.start)
-    )
+    if currentlyHappening {
+      return El.Div[Attr.className => "EventFeature__date EventFeature__date--live"].containing(
+        "On now"
+      )
+    } else {
+      return El.Div[Attr.className => "EventFeature__date"].containing(
+        DateUtils.individualDayFormatter.string(from: eventPeriod.start)
+      )
+    }
+    
   }
 
   var expiryDate: Date {
@@ -37,10 +44,8 @@ struct EventFeature: LandingFeature {
     return eventPeriod.end + 2 * 60 * 60
   }
 
-  /// Returns a link to the most currently relevant information about this event
-  var currentLink: String {
-    guard let liveLink = liveLink else { return eventLink }
-
+  /// Whether the event is currently in progress
+  var currentlyHappening: Bool {
     let currentDate = Date()
     let startPadding: TimeInterval = 15 * 60 // 15 mins
     let endPadding: TimeInterval = 60 * 60 // 60 mins to allow for overrunning event
@@ -48,8 +53,14 @@ struct EventFeature: LandingFeature {
       start: eventPeriod.start - startPadding,
       end: eventPeriod.end + endPadding
     )
+    return paddedEventPeriod.contains(currentDate)
+  }
 
-    if paddedEventPeriod.contains(currentDate) {
+  /// Returns a link to the most currently relevant information about this event
+  var currentLink: String {
+    guard let liveLink = liveLink else { return eventLink }
+
+    if currentlyHappening {
       return liveLink
     } else {
       return eventLink

--- a/static/src/styles/EventFeature.styl
+++ b/static/src/styles/EventFeature.styl
@@ -14,12 +14,20 @@
   }
 }
 
+.EventFeature--text-dark {
+  color: $Color__dark;
+}
+
+.EventFeature--text-light {
+  color: $Color__light;
+}
+
 .EventFeature__date {
   position: absolute;
-  left: grid(1);
   right: grid(1);
   bottom: grid(1);
   text-align: right;
+  display: inline-block;
 
   font-family: $Text__primaryFont;
   text-transform: uppercase;
@@ -29,10 +37,8 @@
   opacity: 0.8;
 }
 
-.EventFeature--text-dark {
-  color: $Color__dark;
-}
-
-.EventFeature--text-light {
-  color: $Color__light;
+.EventFeature__date--live {
+  padding: grid(0.3) grid(1);
+  border-radius: grid(0.5);
+  border: 0.2em solid #FEBC2B;
 }


### PR DESCRIPTION
Tells ya when the event's happening right now

Screenshots (for frontend changes only):

Previously
<img width="1439" alt="screen shot 2017-10-31 at 09 57 50" src="https://user-images.githubusercontent.com/3105017/32218188-12692f2c-be22-11e7-87d5-ee3721e16468.png">

Now
<img width="1439" alt="screen shot 2017-10-31 at 09 57 21" src="https://user-images.githubusercontent.com/3105017/32218197-17fe5444-be22-11e7-9a73-71188dbed48e.png">
