### PR TITLE
Fix bug in GitUtils

### DIFF
--- a/Sources/HaCWebsiteLib/Utils/GitUtils.swift
+++ b/Sources/HaCWebsiteLib/Utils/GitUtils.swift
@@ -44,7 +44,7 @@ public struct GitUtils {
     let localRepoPath = localPath + "/" + directory
     guard directoryExists(atPath: localRepoPath) else {
       shallowBranchClone(
-        repoURL: "https://github.com/hackersatcambridge/workshops.git",
+        repoURL: repoURL,
         in: localPath,
         directory: directory
       )


### PR DESCRIPTION
GitUtils wasn't respecting the `repoURL` argument