### PR TITLE
Add a route for the constitution

### DIFF
--- a/Sources/HaCWebsite/main.swift
+++ b/Sources/HaCWebsite/main.swift
@@ -7,6 +7,7 @@ Config.checkEnvVars()
 
 // swiftlint:disable:next force_try
 try! WorkshopManager.update()
+try! ConstitutionManager.update()
 
 // This call never returns
 serveWebsite()

--- a/Sources/HaCWebsiteLib/ConstitutionManager.swift
+++ b/Sources/HaCWebsiteLib/ConstitutionManager.swift
@@ -4,7 +4,7 @@ import DotEnv
 
 public struct ConstitutionManager {
   /// The list of workshops as derived from the workshops directory last time it was updated
-  public static var mdConstitution: String = "Baby got HaC"
+  public static var mdConstitution: String = "For some reason the constitution cannot be displayed, please contact the site administrators."
 
   /// Used to avoid multiple git pulls being run simultaneously
   private static let serialQueue = DispatchQueue(label: "com.hac.website.const-pull-queue")

--- a/Sources/HaCWebsiteLib/ConstitutionManager.swift
+++ b/Sources/HaCWebsiteLib/ConstitutionManager.swift
@@ -3,34 +3,33 @@ import Dispatch
 import DotEnv
 
 public struct ConstitutionManager {
-  /// The list of workshops as derived from the workshops directory last time it was updated
+  /// The markdown of the constitution from the GitHub repository
   public static var mdConstitution: String = "For some reason the constitution cannot be displayed, please contact the site administrators."
 
   /// Used to avoid multiple git pulls being run simultaneously
   private static let serialQueue = DispatchQueue(label: "com.hac.website.const-pull-queue")
 
-  private static let data_directory = "constitution"
+  private static let dataDirectory = "constitution"
 
   /**
-    Ensures that an up-to-date copy of the workshops repo is available locally
+    Ensures that an up-to-date copy of the constitution repo is available locally
     We don't want this function running many times concurrently, hence 'unsafe'
   */
   private static func unsafePull() {
     GitUtils.cloneOrPull(
       repoURL: "https://github.com/hackersatcambridge/constitution.git",
       in: DotEnv.get("DATA_DIR")!,
-      directory: data_directory
+      directory: dataDirectory
     )
   }
 
   /**
-    Parses each workshop from the workshops repo, creating a Workshop instance
-    These are stored publicly in WorkshopManager.workshops
+    Grabs the constitution markdown and loads it into a string.
 
-    - throws: If the workshops directory does not exist
+    - throws: If the constitution directory does not exist
   */
   private static func getConstitution() throws {
-    let constitutionPath = DotEnv.get("DATA_DIR")! + "/\(data_directory)/constitution.md"
+    let constitutionPath = DotEnv.get("DATA_DIR")! + "/\(dataDirectory)/constitution.md"
       do {
         let constitutionMarkdown = try String(contentsOfFile: constitutionPath, encoding: .utf8)
         mdConstitution = constitutionMarkdown
@@ -39,7 +38,7 @@ public struct ConstitutionManager {
   }
 
   /**
-    Update the workshops array by pulling changes from the repo.
+    Update the constitution by pulling changes from the repo.
     This should be called whenever it is likely that changes
     have been made to the repo.
   */

--- a/Sources/HaCWebsiteLib/ConstitutionManager.swift
+++ b/Sources/HaCWebsiteLib/ConstitutionManager.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Dispatch
+import DotEnv
+
+public struct ConstitutionManager {
+  /// The list of workshops as derived from the workshops directory last time it was updated
+  public static var mdConstitution: String = "Baby got HaC"
+
+  /// Used to avoid multiple git pulls being run simultaneously
+  private static let serialQueue = DispatchQueue(label: "com.hac.website.ws-pull-queue")
+
+  private static let data_directory = "constitution"
+
+  /**
+    Ensures that an up-to-date copy of the workshops repo is available locally
+    We don't want this function running many times concurrently, hence 'unsafe'
+  */
+  private static func unsafePull() {
+    GitUtils.cloneOrPull(
+      repoURL: "https://github.com/hackersatcambridge/constitution.git",
+      in: DotEnv.get("DATA_DIR")!,
+      directory: data_directory
+    )
+  }
+
+  /**
+    Parses each workshop from the workshops repo, creating a Workshop instance
+    These are stored publicly in WorkshopManager.workshops
+
+    - throws: If the workshops directory does not exist
+  */
+  private static func getConstitution() throws {
+    let constitutionPath = DotEnv.get("DATA_DIR")! + "/\(data_directory)/constitution.md"
+      do {
+        let constitutionMarkdown = try String(contentsOfFile: constitutionPath, encoding: .utf8)
+        mdConstitution = constitutionMarkdown
+      } catch {
+      }
+  }
+
+  /**
+    Update the workshops array by pulling changes from the repo.
+    This should be called whenever it is likely that changes
+    have been made to the repo.
+  */
+  public static func update() throws {
+    // Use a serial queue to avoid concurrent Git processes
+    try serialQueue.sync {
+      unsafePull()
+      try getConstitution()
+    }
+  }
+}

--- a/Sources/HaCWebsiteLib/ConstitutionManager.swift
+++ b/Sources/HaCWebsiteLib/ConstitutionManager.swift
@@ -7,7 +7,7 @@ public struct ConstitutionManager {
   public static var mdConstitution: String = "Baby got HaC"
 
   /// Used to avoid multiple git pulls being run simultaneously
-  private static let serialQueue = DispatchQueue(label: "com.hac.website.ws-pull-queue")
+  private static let serialQueue = DispatchQueue(label: "com.hac.website.const-pull-queue")
 
   private static let data_directory = "constitution"
 

--- a/Sources/HaCWebsiteLib/Controllers/ConstitutionController.swift
+++ b/Sources/HaCWebsiteLib/Controllers/ConstitutionController.swift
@@ -1,0 +1,9 @@
+import Kitura
+
+struct ConstitutionController {
+    static var handler: RouterHandler = { request, response, next in
+    try response.send(
+      Constitution(mdText: ConstitutionManager.mdConstitution).node.render()
+    ).end()
+  }
+}

--- a/Sources/HaCWebsiteLib/Controllers/GitHubWebhookController.swift
+++ b/Sources/HaCWebsiteLib/Controllers/GitHubWebhookController.swift
@@ -1,7 +1,9 @@
 import Kitura
 
 struct GitHubWebhookController {
-  static var handler: RouterHandler = { _, _, _ in
-    try WorkshopManager.update()
+  static func handler(updater: @escaping () throws -> Void) -> RouterHandler {
+    return { _, _, _ in
+      try updater()
+    }
   }
 }

--- a/Sources/HaCWebsiteLib/Utils/GitUtils.swift
+++ b/Sources/HaCWebsiteLib/Utils/GitUtils.swift
@@ -3,7 +3,7 @@ import Foundation
 public struct GitUtils {
   /**
     Runs a `git clone` command at the specified path, cloning into the specified directory
-    
+
     - parameters:
       - repoURL: The URL to the Git repository to clone
       - localPath: The local path in which to run the `clone`
@@ -21,7 +21,7 @@ public struct GitUtils {
 
   /**
     Runs a `git pull` command at the specified path
-  
+
     - parameters:
       - in: The path to the local repository in which to pull
       - remote: The name of the remote to pull from
@@ -34,7 +34,7 @@ public struct GitUtils {
 
   /**
     Clones a Git repository if it doesn't already exist at the specified location, updating it otherwise
-   
+
     - parameters:
       - repoURL: The URL to the Git repository
       - localPath: The local path to the parent directory of the repository
@@ -51,17 +51,17 @@ public struct GitUtils {
 
       return
     }
-    
+
     pull(in: localRepoPath)
   }
 }
 
 /**
   Executes a shell command synchronously, returning the exit code
-  
+
   - parameters:
     - args: The arguments to the shell command, starting with the command itself
-    
+
   - returns:
     The exit code of the command
 */

--- a/Sources/HaCWebsiteLib/ViewModels/Constitution.swift
+++ b/Sources/HaCWebsiteLib/ViewModels/Constitution.swift
@@ -7,7 +7,7 @@ struct Constitution {
     return UI.Pages.base(
       title: "Hackers at Cambridge",
       content: Fragment(
-        El.Div[Attr.className => "LandingTop"].containing(
+        El.Div[Attr.className => "Constitution"].containing(
           TextNode(Text(markdown: mdText).html, escapeLevel: .unsafeRaw)
         )
       )

--- a/Sources/HaCWebsiteLib/ViewModels/Constitution.swift
+++ b/Sources/HaCWebsiteLib/ViewModels/Constitution.swift
@@ -1,0 +1,16 @@
+import HaCTML
+import Foundation
+
+struct Constitution {
+  let mdText : String
+  var node: Node {
+    return UI.Pages.base(
+      title: "Hackers at Cambridge",
+      content: Fragment(
+        El.Div[Attr.className => "LandingTop"].containing(
+          TextNode(Text(markdown: mdText).html, escapeLevel: .unsafeRaw)
+        )
+      )
+    )
+  }
+}

--- a/Sources/HaCWebsiteLib/routes.swift
+++ b/Sources/HaCWebsiteLib/routes.swift
@@ -20,10 +20,14 @@ func getWebsiteRouter() -> Router {
   router.all("/static", middleware: StaticFileServer(path: "./static/dist"))
 
   /// Intended for use by GitHub webhooks
+  // TODO: make the GitHubWebhookController configurable!
   router.post("/api/refresh_workshops", handler: GitHubWebhookController.handler)
+  router.post("/api/refresh_constitution", handler: GitHubWebhookController.handler)
+
 
   router.get("/", handler: LandingPageController.handler)
   router.get("/workshops", handler: WorkshopsController.handler)
+  router.get("/constitution", handler: ConstitutionController.handler)
 
   // MARK: Features in progress
   router.get("/beta/landing-update-feed", handler: LandingUpdateFeedController.handler)

--- a/Sources/HaCWebsiteLib/routes.swift
+++ b/Sources/HaCWebsiteLib/routes.swift
@@ -20,7 +20,6 @@ func getWebsiteRouter() -> Router {
   router.all("/static", middleware: StaticFileServer(path: "./static/dist"))
 
   /// Intended for use by GitHub webhooks
-  // TODO: make the GitHubWebhookController configurable!
   router.post("/api/refresh_workshops", handler: GitHubWebhookController.handler(updater: WorkshopManager.update))
   router.post("/api/refresh_constitution", handler: GitHubWebhookController.handler(updater: ConstitutionManager.update))
 

--- a/Sources/HaCWebsiteLib/routes.swift
+++ b/Sources/HaCWebsiteLib/routes.swift
@@ -21,8 +21,8 @@ func getWebsiteRouter() -> Router {
 
   /// Intended for use by GitHub webhooks
   // TODO: make the GitHubWebhookController configurable!
-  router.post("/api/refresh_workshops", handler: GitHubWebhookController.handler)
-  router.post("/api/refresh_constitution", handler: GitHubWebhookController.handler)
+  router.post("/api/refresh_workshops", handler: GitHubWebhookController.handler(updater: WorkshopManager.update))
+  router.post("/api/refresh_constitution", handler: GitHubWebhookController.handler(updater: ConstitutionManager.update))
 
 
   router.get("/", handler: LandingPageController.handler)

--- a/static/src/styles/Constitution.styl
+++ b/static/src/styles/Constitution.styl
@@ -1,0 +1,3 @@
+.Constitution {
+    margin: 10px;
+}

--- a/static/src/styles/main.styl
+++ b/static/src/styles/main.styl
@@ -5,3 +5,4 @@
 @require './NotFound';
 @require './ImageHero';
 @require './EventFeature';
+@require './Constitution';


### PR DESCRIPTION
Fixes #103 .

![image](https://user-images.githubusercontent.com/10348641/32226971-e34ed154-be41-11e7-9894-dba00dfbd096.png)

Changes:

 - a route `/constitution` is added that will show the latest version of constitution

 - the constitution is loaded directly from the [constitution repository](https://github.com/hackersatcambridge/constitution)

 - a webhook has been added to update the version of the constitution the site uses, and webhook controller is now configurable



