### PR TITLE
Add subtle button shadow

### DIFF
--- a/static/src/styles/core/interaction.styl
+++ b/static/src/styles/core/interaction.styl
@@ -6,6 +6,7 @@
   color: white;
   border-radius: 3px;
   transition: background 0.2s;
+  box-shadow: 0px 2px 6px alpha(darken($Color__bright1, 50%), 0.3);
 }
 
 .BigButton:hover {


### PR DESCRIPTION
Fixes # .

Screenshots (for frontend changes only):

Previously
<img width="579" alt="screen shot 2017-11-09 at 12 29 14" src="https://user-images.githubusercontent.com/3105017/32607344-94788258-c550-11e7-9705-c70ff4f21df0.png">

Now
<img width="603" alt="screen shot 2017-11-09 at 13 18 30" src="https://user-images.githubusercontent.com/3105017/32607337-8b23d0b8-c550-11e7-9554-675c8c239ced.png">

