### PR TITLE
Bump Kitura to v2.0.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -29,21 +29,21 @@
         }
       },
       {
-        "package": "CPostgreSQL",
-        "repositoryURL": "https://github.com/vapor-community/cpostgresql.git",
-        "state": {
-          "branch": null,
-          "revision": "33f0f94f023ab61ccd0ba2f076dd6a448be853e3",
-          "version": "2.1.0"
-        }
-      },
-      {
         "package": "Core",
         "repositoryURL": "https://github.com/vapor/core.git",
         "state": {
           "branch": null,
           "revision": "b8330808f4f6b69941961afe8ad6b015562f7b7c",
           "version": "2.1.2"
+        }
+      },
+      {
+        "package": "CPostgreSQL",
+        "repositoryURL": "https://github.com/vapor-community/cpostgresql.git",
+        "state": {
+          "branch": null,
+          "revision": "33f0f94f023ab61ccd0ba2f076dd6a448be853e3",
+          "version": "2.1.0"
         }
       },
       {
@@ -65,15 +65,6 @@
         }
       },
       {
-        "package": "HTMLString",
-        "repositoryURL": "https://github.com/alexaubry/HTMLString",
-        "state": {
-          "branch": null,
-          "revision": "f6cd285dce271ca2e22ffc5206174a2900a26d7c",
-          "version": "3.0.0"
-        }
-      },
-      {
         "package": "HeliumLogger",
         "repositoryURL": "https://github.com/IBM-Swift/HeliumLogger.git",
         "state": {
@@ -83,12 +74,30 @@
         }
       },
       {
+        "package": "HTMLString",
+        "repositoryURL": "https://github.com/alexaubry/HTMLString",
+        "state": {
+          "branch": null,
+          "revision": "f6cd285dce271ca2e22ffc5206174a2900a26d7c",
+          "version": "3.0.0"
+        }
+      },
+      {
         "package": "Kitura",
         "repositoryURL": "https://github.com/IBM-Swift/Kitura.git",
         "state": {
           "branch": null,
-          "revision": "e02c756134c5b399cfc45f186bc2c6f1d51032d1",
-          "version": "1.7.9"
+          "revision": "744a8fbc25a94f598d77662fd71eaa25d789c3fe",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "package": "Kitura-net",
+        "repositoryURL": "https://github.com/IBM-Swift/Kitura-net.git",
+        "state": {
+          "branch": null,
+          "revision": "c29812e62855d34d32305e1dc06d2f1df5224df7",
+          "version": "1.7.19"
         }
       },
       {
@@ -101,12 +110,12 @@
         }
       },
       {
-        "package": "Kitura-net",
-        "repositoryURL": "https://github.com/IBM-Swift/Kitura-net.git",
+        "package": "KituraContracts",
+        "repositoryURL": "https://github.com/IBM-Swift/KituraContracts.git",
         "state": {
           "branch": null,
-          "revision": "c29812e62855d34d32305e1dc06d2f1df5224df7",
-          "version": "1.7.19"
+          "revision": "60ad79cfffeeb9693f53dd68067783d4fde5dc4d",
+          "version": "0.0.14"
         }
       },
       {
@@ -173,24 +182,6 @@
         }
       },
       {
-        "package": "SQLite",
-        "repositoryURL": "https://github.com/vapor/sqlite.git",
-        "state": {
-          "branch": null,
-          "revision": "9aceb6a0d7b1698a557647493bd78b030dad468b",
-          "version": "2.3.1"
-        }
-      },
-      {
-        "package": "SSLService",
-        "repositoryURL": "https://github.com/IBM-Swift/BlueSSLService.git",
-        "state": {
-          "branch": null,
-          "revision": "7adf7cacc447d447df5dcc3058cabd402177c5aa",
-          "version": "0.12.64"
-        }
-      },
-      {
         "package": "Signals",
         "repositoryURL": "https://github.com/IBM-Swift/BlueSignals.git",
         "state": {
@@ -206,6 +197,24 @@
           "branch": null,
           "revision": "00b126a2c19520bbf51cd26e8c0cc41dacbc5a05",
           "version": "0.12.76"
+        }
+      },
+      {
+        "package": "SQLite",
+        "repositoryURL": "https://github.com/vapor/sqlite.git",
+        "state": {
+          "branch": null,
+          "revision": "9aceb6a0d7b1698a557647493bd78b030dad468b",
+          "version": "2.3.1"
+        }
+      },
+      {
+        "package": "SSLService",
+        "repositoryURL": "https://github.com/IBM-Swift/BlueSSLService.git",
+        "state": {
+          "branch": null,
+          "revision": "7adf7cacc447d447df5dcc3058cabd402177c5aa",
+          "version": "0.12.64"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,8 @@ let package = Package(
     .executable(name: "HaCWebsite", targets: ["HaCWebsite"])
   ],
   dependencies: [
-    .package(url: "https://github.com/IBM-Swift/Kitura.git", .upToNextMinor(from: "1.7.9")),
+    .package(url: "https://github.com/IBM-Swift/Kitura.git", .upToNextMinor(from: "2.0.0")),
+    .package(url: "https://github.com/IBM-Swift/SwiftyJSON.git", .upToNextMinor(from: "17.0.0")),
     .package(url: "https://github.com/IBM-Swift/HeliumLogger.git", .upToNextMinor(from: "1.7.1")),
     .package(url: "https://github.com/IBM-Swift/Kitura-Markdown.git", .upToNextMajor(from: "0.9.1")),
     .package(url: "https://github.com/hackersatcambridge/YamlSwift.git", .upToNextMinor(from: "4.0.0")),
@@ -25,6 +26,7 @@ let package = Package(
     .target(name: "HaCWebsiteLib", dependencies: [
       "HaCTML",
       "Kitura",
+      "SwiftyJSON",
       "HeliumLogger",
       "KituraMarkdown",
       "Yaml",


### PR DESCRIPTION
This PR will bump Kitura up to v2.0.0.
The reason for this is that the old version of Kitura causes a dependency resolution conflict when trying to add the Credentials dependency. 