### PR TITLE
Make Script loading portable

### DIFF
--- a/Sources/HaCWebsiteLib/ViewModels/Script.swift
+++ b/Sources/HaCWebsiteLib/ViewModels/Script.swift
@@ -54,8 +54,10 @@ This class is used in order load front-end scripts from a file relative to the c
 struct Script : Nodeable {
   let file : String
   let definitions : [String: JavaScriptable]
-  let directory = "/root/hac-website/Sources/HaCWebsiteLib/ViewModels"
+
   var node: Node {
+    let websiteRoot = FileManager.default.currentDirectoryPath
+    let directory = websiteRoot + "/Sources/HaCWebsiteLib/ViewModels"
     let pathToFile = directory + "/" + file
     do {
       var script = try String(contentsOfFile: pathToFile, encoding: .utf8)


### PR DESCRIPTION
Previously were assuming we were running in `/root/hac-website`. Now we don't depend on that
