### PR TITLE
Fix for bad equatable

### DIFF
--- a/Sources/HaCWebsiteLib/Models/Link.swift
+++ b/Sources/HaCWebsiteLib/Models/Link.swift
@@ -8,6 +8,6 @@ struct Link {
 
 extension Link: Equatable {
   static func == (l: Link, r: Link) -> Bool {
-    return (l.title, l.url) == (r.title, r.url)
+    return (l.text, l.url) == (r.text, r.url)
   }
 }


### PR DESCRIPTION
Previously I'd renamed a stored prop and didn't update method. This fixes that bug