### PR TITLE
Add route error handling

### DIFF
--- a/Sources/HaCWebsiteLib/Middleware/ErrorRoutingMiddleware.swift
+++ b/Sources/HaCWebsiteLib/Middleware/ErrorRoutingMiddleware.swift
@@ -1,0 +1,16 @@
+import Foundation
+import Kitura
+
+public class ErrorRoutingMiddleware: RouterMiddleware {
+
+  public func handle(request: RouterRequest, response: RouterResponse, next: @escaping () -> Void) {
+    defer {
+      next()
+    }
+    if response.statusCode != .OK {
+      try? response.send(
+        ServerError().node.render()
+      ).end()
+    }
+  }
+}

--- a/Sources/HaCWebsiteLib/Views/ServerError.swift
+++ b/Sources/HaCWebsiteLib/Views/ServerError.swift
@@ -1,0 +1,26 @@
+import HaCTML
+
+struct ServerError: Nodeable {
+  var node: Node {
+    return Page(
+      title: "Server Error",
+      content: Fragment(
+        El.Div[Attr.className => "ServerError"].containing(
+          El.Img[
+            Attr.className => "SiteLogo",
+            Attr.src => Assets.publicPath("/images/hac-logo-dark.svg"),
+            Attr.alt => "Hackers at Cambridge"
+          ],
+          El.Div[Attr.className => "TagLine"].containing("Cambridge's student tech society"),
+          El.H1[Attr.className => "ServerError__title"].containing("500"),
+          El.P.containing("An internal error has occured..."),
+          El.A[Attr.href => "/"].containing(
+            El.Div[Attr.className => "BigButton"].containing(
+              "Home"
+            )
+          )
+        )
+      )
+    ).node
+  }
+}

--- a/Sources/HaCWebsiteLib/routes.swift
+++ b/Sources/HaCWebsiteLib/routes.swift
@@ -45,7 +45,7 @@ func getWebsiteRouter() -> Router {
   router.get("/beta/landing-update-feed", handler: LandingUpdateFeedController.handler)
 
   router.all("/", middleware: NotFoundMiddleware())
-
+  router.error(ErrorRoutingMiddleware())
 
   return router
 }

--- a/static/src/styles/ServerError.styl
+++ b/static/src/styles/ServerError.styl
@@ -1,0 +1,16 @@
+.ServerError {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.ServerError__title {
+  font-size: 100px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}

--- a/static/src/styles/main.styl
+++ b/static/src/styles/main.styl
@@ -3,6 +3,7 @@
 @require './landing';
 @require './PostCard';
 @require './NotFound';
+@require './ServerError';
 @require './ImageHero';
 @require './EventFeature';
 @require './Constitution';


### PR DESCRIPTION
Fixes #58. 

This PR adds new middleware which will serve a new error page if an error is thrown in any of our routes.
This PR only introduces an error code 500 page which is the most general of server-side errors. This error page also follows the exact same format as the `NotFound` middleware for consistency.

Previously:
![image](https://user-images.githubusercontent.com/23122367/33658035-130d3564-da73-11e7-99f6-658ec90d1316.png)

Now:
![image](https://user-images.githubusercontent.com/23122367/33658041-16d34b52-da73-11e7-8cdd-ece0f6ccb65e.png)
