### PR TITLE
Style the individual workshop page

### DIFF
--- a/Sources/HaCTML/Fragment.swift
+++ b/Sources/HaCTML/Fragment.swift
@@ -28,12 +28,12 @@
 public struct Fragment: Node {
   let nodes: [Node]
 
-  public init(_ nodes: Nodeable...) {
+  public init(_ nodes: Nodeable?...) {
     self.init(nodes)
   }
 
-  public init(_ nodes: [Nodeable]) {
-    self.nodes = nodes.map{ $0.node }
+  public init(_ nodes: [Nodeable?]) {
+    self.nodes = nodes.flatMap{ $0?.node }
   }
 
   public func render() -> String {

--- a/Sources/HaCTML/HTMLElement.swift
+++ b/Sources/HaCTML/HTMLElement.swift
@@ -31,7 +31,7 @@ public struct HTMLElement {
   private func addChildren(nodeables: [Nodeable?]) -> HTMLElement {
     precondition(child == nil, "Cannot add children to an element that already has children")
 
-    return clone(child: Fragment(nodeables.flatMap({ $0?.node })))
+    return clone(child: Fragment(nodeables))
   }
 
   /**

--- a/Sources/HaCWebsiteLib/Views/BackBar.swift
+++ b/Sources/HaCWebsiteLib/Views/BackBar.swift
@@ -2,13 +2,15 @@ import HaCTML
 import Foundation
 
 struct BackBar: Nodeable {
+  let backLinkText: String
+  let backLinkURL: String
   var node: Node {
     return El.Div[
       Attr.className => "BackBar"
     ].containing(
-      El.A[Attr.className => "BackBar__backButton", Attr.href => "/"].containing(
+      El.A[Attr.className => "BackBar__backButton", Attr.href => backLinkURL].containing(
         El.Div[Attr.className => "BigButton BigButton--back"].containing(
-          "Home"
+          backLinkText
         )
       ),
       El.A[Attr.href => "/", Attr.className => "BackBar__branding"].containing(

--- a/Sources/HaCWebsiteLib/Views/Workshops/IndividualWorkshopPage.swift
+++ b/Sources/HaCWebsiteLib/Views/Workshops/IndividualWorkshopPage.swift
@@ -1,4 +1,5 @@
 import HaCTML
+import Foundation
 
 // swiftlint:disable line_length
 
@@ -7,44 +8,52 @@ struct IndividualWorkshopPage {
     return Page(
       title: "Hackers at Cambridge",
       content: Fragment(
+        BackBar(backLinkText: "Workshops", backLinkURL: "/workshops"),
         hero, // A big beautiful header
         description, // Who, What, Why
-        content // The content of the workshop
+        content, // The content of the workshop
+        furtherReading
       )
     ).node
   }
 
   var hero: Node {
     return El.Div[Attr.className => "WorkshopHero"].containing(
-      "Hero goes here (similar to landing hero)"
+      ImageHero(
+        background: .image(Assets.publicPath("/images/rustbg.png")),
+        imagePath: Assets.publicPath("/images/rustfg.png"),
+        alternateText: "Programming in Rust"
+      )
     )
   }
 
   var description: Node {
     return El.Div[Attr.className => "WorkshopDescription"].containing(
-      El.H1[Attr.className => "WorkshopDescription__title"].containing("Intro to Swift"),
-      Markdown("""
-        If you work with code or data then being comfortable with the command line is essential to your productivity. This workshop will explain and demonstrate the usefulness of the UNIX* shell, Bash.
-        We’ll take you through the basics and then show you many useful commands for day-to-day tasks and how to chain commands together using *pipes* and *redirects* (and explain what they are!).
+      El.H1[Attr.className => "WorkshopDescription__title Text--headline"].containing("Programming in Rust"),
+      El.Div[Attr.className => "WorkshopDescription__descriptionText"].containing(
+        Markdown("""
+          If you work with code or data then being comfortable with the command line is essential to your productivity. This workshop will explain and demonstrate the usefulness of the UNIX* shell, Bash.
+          We’ll take you through the basics and then show you many useful commands for day-to-day tasks and how to chain commands together using *pipes* and *redirects* (and explain what they are!).
 
-        In particular we will cover:
-        - Basic syntax of a Bash command
-        - How to find out what commands mean with `man`
-        - Navigating the filesystem with `ls` and `cd`
-        - Writing to the filesystem with `touch`, `rm`, `mkdir`, `nano`
-        - How to get out of a hanging program with ctrl + C
-        - How to chain commands togather using _pipes_ (`|`) and _redirects_ (`>>`)
+          In particular we will cover:
+          - Basic syntax of a Bash command
+          - How to find out what commands mean with `man`
+          - Navigating the filesystem with `ls` and `cd`
+          - Writing to the filesystem with `touch`, `rm`, `mkdir`, `nano`
+          - How to get out of a hanging program with ctrl + C
+          - How to chain commands togather using _pipes_ (`|`) and _redirects_ (`>>`)
 
-        *although Bash is a UNIX/POSIX/Linux/macOS thing, it's still something that can come incredibly in handy even on windows!
-      """),
-      El.Div[Attr.className => "WorkshopDescription__prerequisites"].containing(
+          *although Bash is a UNIX/POSIX/Linux/macOS thing, it's still something that can come incredibly in handy even on windows!
+        """)
+      ),
+      El.Div[Attr.className => "WorkshopDescription__detail"].containing(
         El.H1[Attr.className => "Text--sectionHeading"].containing("Prerequisites"),
         Markdown("""
           - Basic programing experience
           - Basic familiarity with the command line
         """)
       ),
-      El.Div[Attr.className => "WorkshopDescription__whoFor"].containing(
+      El.Div[Attr.className => "WorkshopDescription__detail"].containing(
         El.H1[Attr.className => "Text--sectionHeading"].containing("Who it's for"),
         Markdown("""
           This is for you if you:
@@ -54,27 +63,79 @@ struct IndividualWorkshopPage {
           - Haven't written code but want to learn the best tools for the job
         """)
       ),
-      El.Div[Attr.className => "WorkshopDescription__setUp"].containing(
+      El.Div[Attr.className => "WorkshopDescription__detail"].containing(
         El.H1[Attr.className => "Text--sectionHeading"].containing("Set up instructions"),
         Markdown("""
           Please make sure you have Swift and Git installed.
           Insert more details here
         """)
+      ),
+      El.Div[Attr.className => "WorkshopDescription__detail"].containing(
+        contributors
       )
     )
   }
 
+  var contributors: Nodeable {
+    let contributors = ["Richard HaC", "Jane Doe"]
+    let thanks = ["Judge Business School", "HaCky Hal the Chatbot Pal"]
+
+    let contributorsText = contributors.isEmpty ? nil : "Contributors: " + contributors.joined(separator: ", ")
+    let thanksText = thanks.isEmpty ? nil : "Thanks to: " + thanks.joined(separator: ", ")
+
+    return Fragment(
+      contributorsText,
+      El.Br,
+      thanksText
+    )
+  }
+
+  var slidesButton: Node? {
+    // TODO: Use actual data for this
+    let slidesLink: URL? = URL(string: "https://docs.google.com/presentation/d/1tV3VHcqAhVIFc6UTXCoY6-7eQdcPqdPHy6P3XGPi2X0/present#slide=id.p")!
+
+    return slidesLink.map {
+      El.A[Attr.href => $0.absoluteString, Attr.target => "_blank"].containing(
+        El.Div[Attr.className => "BigButton BigButton--inline"].containing(
+          "View slides"
+        )
+      )
+    }
+  }
+
+  var recordingButton: Node? {
+    // TODO: Use actual data for this
+    let recordingLink: URL? = URL(string: "https://www.youtube.com/watch?v=FHG2oizTlpY")!
+
+    return recordingLink.map {
+      El.A[Attr.href => $0.absoluteString, Attr.target => "_blank"].containing(
+        El.Div[Attr.className => "BigButton BigButton--inline BigButton--youtube"].containing(
+          "View video recording"
+        )
+      )
+    }
+  }
+
+  var examplesButton: Node? {
+    // TODO: Use actual data for this
+    let examplesLink: URL? = URL(string: "https://github.com/hackersatcambridge/workshop-example/tree/master/examples")!
+
+    return examplesLink.map {
+      El.A[Attr.href => $0.absoluteString, Attr.target => "_blank"].containing(
+        El.Div[Attr.className => "BigButton BigButton--inline BigButton--github"].containing(
+          "View code examples on GitHub"
+        )
+      )
+    }
+  }
+
   var content: Node {
     return El.Div[Attr.className => "WorkshopContent"].containing(
-      El.Div[Attr.className => "BigButton"].containing(
-        "View code examples on GitHub"
-      ),
+      slidesButton, recordingButton, examplesButton,
       Markdown("""
-        Content goes here
-
         Snake Game
         ===
-        ## **Learning aims**
+        ## Learning aims
         * Make you confortable with following simple installation instructions 
         * Apply basic programming concepts: variables, `if` statements, `for` loops
         * Understand and interact with helper functions, ready-made code
@@ -82,7 +143,7 @@ struct IndividualWorkshopPage {
         * Working with **matrices** 
         * Your first view of the world of games :) 
 
-        ## ***An overview of what is already in the code**
+        ## An overview of what is already in the code
         _If you're confortable with figuring out what the helper code does on your own, you can skip this bit._
 
         * We have some notion of how we are going to start off this game. In this simple implementation, we'll be modelling the snake game by a 8x8 matrix. **What is a matrix?** Simply put, just an array of arrays, all of the same size. That means, an array `playMatrix` containing 8 arrays, each with 8 elements of their own. This gives us 64 little cells where our snake can run freely (_obviously without biting its tail_)  
@@ -124,6 +185,35 @@ struct IndividualWorkshopPage {
 
         ...
       """)
+    )
+  }
+
+  var furtherReading: Node {
+    // TODO: Use actual data for this
+    let furtherReadingLinks = [
+      Link(
+        text: "Kitura Website",
+        url: URL(string: "http://www.kitura.io")!
+      ),
+      Link(
+        text: "The answer to all your troubles",
+        url: URL(string: "http://www.kitura.io")!
+      ),
+      Link(
+        text: "Someone's blog",
+        url: URL(string: "http://www.kitura.io")!
+      )
+    ]
+
+    return El.Div[Attr.className => "WorkshopFurtherReading"].containing(
+      El.H1[Attr.className => "Text--sectionHeading"].containing("Further reading"),
+      El.Ul.containing(
+        furtherReadingLinks.map {
+          El.A[Attr.href => $0.url.absoluteString].containing(
+            El.Li.containing($0.text)
+          )
+        }
+      )
     )
   }
 }

--- a/Sources/HaCWebsiteLib/Views/Workshops/WorkshopsIndexPage/WorkshopsIndexPage.swift
+++ b/Sources/HaCWebsiteLib/Views/Workshops/WorkshopsIndexPage/WorkshopsIndexPage.swift
@@ -13,7 +13,7 @@ struct WorkshopsIndexPage {
     return Page(
       title: "Hackers at Cambridge",
       content: El.Div[Attr.className => "WorkshopsIndexPage"].containing(
-        BackBar(),
+        BackBar(backLinkText: "Home", backLinkURL: "/"),
         WorkshopsIndexAbout(),
         WorkshopsIndexSchedule(),
         WorkshopsIndexGetInvolved()

--- a/static/src/styles/ContentCard.styl
+++ b/static/src/styles/ContentCard.styl
@@ -1,0 +1,11 @@
+.ContentCard {
+  background: white;
+  padding: grid(4);
+  width: 100%;
+  border-radius: $Layout__normalBorderRadius;
+  box-shadow: 0px 2px 6px alpha(darken(white, 50%), 0.3);
+}
+
+.ContentCard--fill {
+  height: 100%;
+}

--- a/static/src/styles/Workshop/WorkshopContent.styl
+++ b/static/src/styles/Workshop/WorkshopContent.styl
@@ -1,0 +1,7 @@
+.WorkshopContent {
+  border-top: 2px solid lightgrey;
+  padding: grid(4);
+  padding-top: grid(8);
+  max-width: grid(120);
+  margin: 0 auto;
+}

--- a/static/src/styles/Workshop/WorkshopDescription.styl
+++ b/static/src/styles/Workshop/WorkshopDescription.styl
@@ -1,0 +1,10 @@
+.WorkshopDescription {
+  padding: grid(4);
+  max-width: grid(120);
+  margin: 0 auto;
+}
+
+.WorkshopDescription__detail {
+  padding: 0.7em;
+  box-sizing: border-box;
+}

--- a/static/src/styles/Workshop/WorkshopFurtherReading.styl
+++ b/static/src/styles/Workshop/WorkshopFurtherReading.styl
@@ -1,0 +1,7 @@
+.WorkshopFurtherReading {
+  border-top: 2px solid lightgrey;
+  padding: grid(4);
+  padding-top: grid(8);
+  max-width: grid(120);
+  margin: 0 auto;
+}

--- a/static/src/styles/Workshop/WorkshopHero.styl
+++ b/static/src/styles/Workshop/WorkshopHero.styl
@@ -1,0 +1,3 @@
+.WorkshopHero {
+  height: 20em;
+}

--- a/static/src/styles/Workshop/index.styl
+++ b/static/src/styles/Workshop/index.styl
@@ -1,0 +1,4 @@
+@require './WorkshopHero';
+@require './WorkshopDescription';
+@require './WorkshopContent';
+@require './WorkshopFurtherReading';

--- a/static/src/styles/core/brand.styl
+++ b/static/src/styles/core/brand.styl
@@ -17,6 +17,6 @@
 
 .TagLine {
   Text__headerScale(0);
-  font-family: $Text__monospacedFont;
+  font-family: $Text__monospacedDisplayFont;
   color: $Color__mediumGrayText;
 }

--- a/static/src/styles/core/color.styl
+++ b/static/src/styles/core/color.styl
@@ -5,6 +5,7 @@ $Color__bright1 = #C70F65;
 $Color__bright2 = #430CA6;
 $Color__facebook = #4469b0;
 $Color__youtube = #E22F35;
+$Color__github = #1E1E1E;
 
 $Color__lightBackground = $Color__light;
 $Color__fadedSubtitle = #C7C7C7;
@@ -12,6 +13,7 @@ $Color__lightText = $Color__light;
 $Color__mediumGrayText = $Color__mediumGray;
 $Color__darkText = $Color__dark;
 $Color__brightText = $Color__bright1;
+$Color__inlineCodeText = #BF4232;
 
 body {
   color: $Color__text;

--- a/static/src/styles/core/interaction.styl
+++ b/static/src/styles/core/interaction.styl
@@ -42,3 +42,11 @@
 .BigButton--youtube:hover {
   background: darken($Color__youtube, 20%);
 }
+
+.BigButton--github {
+  background: $Color__github;
+  box-shadow: 0px 2px 6px alpha(darken($Color__github, 50%), 0.3);
+}
+.BigButton--github:hover {
+  background: darken($Color__github, 20%);
+}

--- a/static/src/styles/core/text.styl
+++ b/static/src/styles/core/text.styl
@@ -1,6 +1,7 @@
 $Text__primaryFont = Barlow, 'Helvetica Neue', Arial, sans-serif;
-$Text__monospacedFont = 'Space Mono', 'Menlo', 'Courier New', monospaced;
-$Text__emphasisFont = $Text__monospacedFont;
+$Text__monospacedDisplayFont = 'Space Mono', 'Menlo', 'Courier New', monospaced;
+$Text__codeFont = "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+$Text__emphasisFont = $Text__monospacedDisplayFont;
 
 $Text__baseSize = grid(2);
 
@@ -21,6 +22,7 @@ Text__headerScale($scale) {
 h1, h2, h3, h4, h5, h6 {
   margin-top: 0;
   margin-bottom: ($Text__baseSize / 2);
+  font-weight: 500;
 }
 
 h1 {
@@ -52,6 +54,37 @@ p, ol, ul {
   margin-bottom: $Text__baseSize;
 }
 
+b, strong {
+  font-weight: 500;
+}
+
+:not(pre) > code {
+  font-family: $Text__codeFont;
+  font-size: 0.9em;
+  background: alpha(white, 0.3);
+  color: $Color__inlineCodeText;
+  display: inline-block;
+  padding: 0 grid(0.5);
+  border: 1px solid alpha(gray, 0.2);
+  border-radius: $Layout__normalBorderRadius;
+}
+
+pre {
+  max-width: 100%;
+  overflow: scroll;
+}
+
+pre > code {
+  font-family: $Text__codeFont;
+  font-size: 0.9em;
+  background: alpha(white, 0.3);
+  color: $Color__inlineCodeText;
+  display: inline-block;
+  padding: grid(2);
+  border: 1px solid alpha(gray, 0.2);
+  border-radius: $Layout__normalBorderRadius;
+}
+
 .Text--sectionHeading {
   font-family: $Text__primaryFont;
   text-transform: uppercase;
@@ -65,7 +98,7 @@ p, ol, ul {
   Text__headerScale(3);
   margin-top: grid(3);
   margin-bottom: grid(4);
-  font-family: $Text__monospacedFont;
+  font-family: $Text__monospacedDisplayFont;
   font-weight: 800;
   color: #792359;
   line-height: 1.4em;

--- a/static/src/styles/main.styl
+++ b/static/src/styles/main.styl
@@ -1,6 +1,7 @@
 @require './core';
 @require './build';
 @require './landing';
+@require './ContentCard';
 @require './PostCard';
 @require './NotFound';
 @require './ServerError';
@@ -8,4 +9,5 @@
 @require './EventFeature';
 @require './Constitution';
 @require './BackBar';
+@require './Workshop';
 @require './WorkshopsIndex';


### PR DESCRIPTION
Fixes #159

Notable missing:
- Good handling of code snippets
- Embedding of any content (slides or recording), might not be particularly convenient to do this anyway

Now
<img width="654" alt="screen shot 2018-01-13 at 23 48 27" src="https://user-images.githubusercontent.com/3105017/34911166-5fc186fa-f8bc-11e7-99e1-63ee1092ba91.png">
<img width="653" alt="screen shot 2018-01-13 at 23 48 38" src="https://user-images.githubusercontent.com/3105017/34911167-6174be54-f8bc-11e7-9dcd-a6cee17a9275.png">
<img width="653" alt="screen shot 2018-01-13 at 23 48 50" src="https://user-images.githubusercontent.com/3105017/34911169-631cdd7c-f8bc-11e7-8758-762f12067908.png">
