### PR TITLE
Hook up NewWorkshops data to View

### DIFF
--- a/Sources/HaCWebsite/main.swift
+++ b/Sources/HaCWebsite/main.swift
@@ -8,6 +8,7 @@ Config.checkEnvVars()
 // swiftlint:disable:next force_try
 WorkshopManager.update()
 ConstitutionManager.update()
+NewWorkshopManager.update()
 
 // This call never returns
 serveWebsite()

--- a/Sources/HaCWebsiteLib/Controllers/WorkshopsController.swift
+++ b/Sources/HaCWebsiteLib/Controllers/WorkshopsController.swift
@@ -46,10 +46,14 @@ struct WorkshopsController {
   }
 
   static var workshopHandler: RouterHandler = { request, response, next in 
-    dump(NewWorkshopManager.workshops)
-    try response.send(
-      IndividualWorkshopPage(workshop: NewWorkshopManager.workshops["workshop-example"]!).node.render()
-    ).end()
+    if let workshopId = request.parameters["workshopId"],
+      let workshop = NewWorkshopManager.workshops["workshop-\(workshopId)"] {
+        try response.send(
+          IndividualWorkshopPage(workshop: workshop).node.render()
+        ).end()
+    } else {
+      next()
+    }
   }
 
 }

--- a/Sources/HaCWebsiteLib/Controllers/WorkshopsController.swift
+++ b/Sources/HaCWebsiteLib/Controllers/WorkshopsController.swift
@@ -5,7 +5,9 @@ struct WorkshopsController {
   static var handler: RouterHandler = { request, response, next in
     try response.send(
       WorkshopsIndexPage(
-        allWorkshops: Array(NewWorkshopManager.workshops.values).sorted { $0.title < $1.title }
+        allWorkshops: Array(NewWorkshopManager.workshops.values)
+          .sorted { $0.title < $1.title }
+          .filter { $0.workshopId != "example" }
       ).node.render()
     ).end()
   }

--- a/Sources/HaCWebsiteLib/Controllers/WorkshopsController.swift
+++ b/Sources/HaCWebsiteLib/Controllers/WorkshopsController.swift
@@ -2,45 +2,10 @@ import Kitura
 
 struct WorkshopsController {
 
-  static let upcomingWorkshopCards = [
-    PostCard(
-      title: "Intro to Python",
-      category: .workshop,
-      description: "Snakes are dangerous",
-      backgroundColor: "#852503",
-      imageURL: "/static/images/functions_frame.png"
-    ),
-    PostCard(
-      title: "Intermediate Swift",
-      category: .workshop,
-      description: "Take your entire life to the next level",
-      backgroundColor: "green",
-      imageURL: "/static/images/workshop.jpg"
-    )
-  ]
-
-  static let previousWorkshopCards = [
-    PostCard(
-      title: "Intermediate Swift",
-      category: .workshop,
-      description: "Take your entire life to the next level",
-      backgroundColor: "#852503",
-      imageURL: "/static/images/functions_frame.png"
-    ),
-    PostCard(
-      title: "Binary Exploitation",
-      category: .workshop,
-      description: "Learn all the things.",
-      backgroundColor: "green",
-      imageURL: "/static/images/workshop.jpg"
-    )
-  ]
-
   static var handler: RouterHandler = { request, response, next in
     try response.send(
       WorkshopsIndexPage(
-        upcomingWorkshops: upcomingWorkshopCards,
-        previousWorkshops: previousWorkshopCards
+        allWorkshops: Array(NewWorkshopManager.workshops.values).sorted { $0.title < $1.title }
       ).node.render()
     ).end()
   }

--- a/Sources/HaCWebsiteLib/Controllers/WorkshopsController.swift
+++ b/Sources/HaCWebsiteLib/Controllers/WorkshopsController.swift
@@ -46,8 +46,9 @@ struct WorkshopsController {
   }
 
   static var workshopHandler: RouterHandler = { request, response, next in 
+    dump(NewWorkshopManager.workshops)
     try response.send(
-      IndividualWorkshopPage().node.render()
+      IndividualWorkshopPage(workshop: NewWorkshopManager.workshops["workshop-example"]!).node.render()
     ).end()
   }
 

--- a/Sources/HaCWebsiteLib/Views/Workshops/IndividualWorkshopPage.swift
+++ b/Sources/HaCWebsiteLib/Views/Workshops/IndividualWorkshopPage.swift
@@ -4,9 +4,11 @@ import Foundation
 // swiftlint:disable line_length
 
 struct IndividualWorkshopPage {
+  let workshop: NewWorkshop
+
   var node: Node {
     return Page(
-      title: "Hackers at Cambridge",
+      title: "\(workshop.title) | Hackers at Cambridge",
       content: Fragment(
         BackBar(backLinkText: "Workshops", backLinkURL: "/workshops"),
         hero, // A big beautiful header
@@ -20,68 +22,32 @@ struct IndividualWorkshopPage {
   var hero: Node {
     return El.Div[Attr.className => "WorkshopHero"].containing(
       ImageHero(
-        background: .image(Assets.publicPath("/images/rustbg.png")),
-        imagePath: Assets.publicPath("/images/rustfg.png"),
-        alternateText: "Programming in Rust"
+        background: workshop.promoImageBackground,
+        imagePath: workshop.promoImageForeground,
+        alternateText: workshop.title
       )
     )
   }
 
   var description: Node {
-    return El.Div[Attr.className => "WorkshopDescription"].containing(
-      El.H1[Attr.className => "WorkshopDescription__title Text--headline"].containing("Programming in Rust"),
-      El.Div[Attr.className => "WorkshopDescription__descriptionText"].containing(
-        Markdown("""
-          If you work with code or data then being comfortable with the command line is essential to your productivity. This workshop will explain and demonstrate the usefulness of the UNIX* shell, Bash.
-          We’ll take you through the basics and then show you many useful commands for day-to-day tasks and how to chain commands together using *pipes* and *redirects* (and explain what they are!).
-
-          In particular we will cover:
-          - Basic syntax of a Bash command
-          - How to find out what commands mean with `man`
-          - Navigating the filesystem with `ls` and `cd`
-          - Writing to the filesystem with `touch`, `rm`, `mkdir`, `nano`
-          - How to get out of a hanging program with ctrl + C
-          - How to chain commands togather using _pipes_ (`|`) and _redirects_ (`>>`)
-
-          *although Bash is a UNIX/POSIX/Linux/macOS thing, it's still something that can come incredibly in handy even on windows!
-        """)
-      ),
-      El.Div[Attr.className => "WorkshopDescription__detail"].containing(
+    return El.Div[Attr.className => "WorkshopDescription"].containing([
+      El.H1[Attr.className => "WorkshopDescription__title Text--headline"].containing(workshop.title),
+      El.Div[Attr.className => "WorkshopDescription__descriptionText"].containing(workshop.description),
+      El.Div[Attr.className => "WorkshopDescription__detail"].containing([
         El.H1[Attr.className => "Text--sectionHeading"].containing("Prerequisites"),
-        Markdown("""
-          - Basic programing experience
-          - Basic familiarity with the command line
-        """)
-      ),
-      El.Div[Attr.className => "WorkshopDescription__detail"].containing(
-        El.H1[Attr.className => "Text--sectionHeading"].containing("Who it's for"),
-        Markdown("""
-          This is for you if you:
-          - Are starting to learn how to program
-          - Are an expert programmer that has never used the command line
-          - Aren’t convinced that the command line is useful
-          - Haven't written code but want to learn the best tools for the job
-        """)
-      ),
-      El.Div[Attr.className => "WorkshopDescription__detail"].containing(
+        workshop.prerequisites
+      ]),
+      El.Div[Attr.className => "WorkshopDescription__detail"].containing([
         El.H1[Attr.className => "Text--sectionHeading"].containing("Set up instructions"),
-        Markdown("""
-          Please make sure you have Swift and Git installed.
-          Insert more details here
-        """)
-      ),
-      El.Div[Attr.className => "WorkshopDescription__detail"].containing(
-        contributors
-      )
-    )
+        workshop.setupInstructions
+      ]),
+      El.Div[Attr.className => "WorkshopDescription__detail"].containing(contributors)
+    ])
   }
 
   var contributors: Nodeable {
-    let contributors = ["Richard HaC", "Jane Doe"]
-    let thanks = ["Judge Business School", "HaCky Hal the Chatbot Pal"]
-
-    let contributorsText = contributors.isEmpty ? nil : "Contributors: " + contributors.joined(separator: ", ")
-    let thanksText = thanks.isEmpty ? nil : "Thanks to: " + thanks.joined(separator: ", ")
+    let contributorsText = workshop.contributors.isEmpty ? nil : "Contributors: " + workshop.contributors.joined(separator: ", ")
+    let thanksText = workshop.thanks.isEmpty ? nil : "Thanks to: " + workshop.thanks.joined(separator: ", ")
 
     return Fragment(
       contributorsText,
@@ -91,10 +57,7 @@ struct IndividualWorkshopPage {
   }
 
   var slidesButton: Node? {
-    // TODO: Use actual data for this
-    let slidesLink: URL? = URL(string: "https://docs.google.com/presentation/d/1tV3VHcqAhVIFc6UTXCoY6-7eQdcPqdPHy6P3XGPi2X0/present#slide=id.p")!
-
-    return slidesLink.map {
+    return workshop.slidesLink.map {
       El.A[Attr.href => $0.absoluteString, Attr.target => "_blank"].containing(
         El.Div[Attr.className => "BigButton BigButton--inline"].containing(
           "View slides"
@@ -104,10 +67,7 @@ struct IndividualWorkshopPage {
   }
 
   var recordingButton: Node? {
-    // TODO: Use actual data for this
-    let recordingLink: URL? = URL(string: "https://www.youtube.com/watch?v=FHG2oizTlpY")!
-
-    return recordingLink.map {
+    return workshop.recordingLink.map {
       El.A[Attr.href => $0.absoluteString, Attr.target => "_blank"].containing(
         El.Div[Attr.className => "BigButton BigButton--inline BigButton--youtube"].containing(
           "View video recording"
@@ -117,10 +77,7 @@ struct IndividualWorkshopPage {
   }
 
   var examplesButton: Node? {
-    // TODO: Use actual data for this
-    let examplesLink: URL? = URL(string: "https://github.com/hackersatcambridge/workshop-example/tree/master/examples")!
-
-    return examplesLink.map {
+    return workshop.examplesLink.map {
       El.A[Attr.href => $0.absoluteString, Attr.target => "_blank"].containing(
         El.Div[Attr.className => "BigButton BigButton--inline BigButton--github"].containing(
           "View code examples on GitHub"
@@ -132,88 +89,24 @@ struct IndividualWorkshopPage {
   var content: Node {
     return El.Div[Attr.className => "WorkshopContent"].containing(
       slidesButton, recordingButton, examplesButton,
-      Markdown("""
-        Snake Game
-        ===
-        ## Learning aims
-        * Make you confortable with following simple installation instructions 
-        * Apply basic programming concepts: variables, `if` statements, `for` loops
-        * Understand and interact with helper functions, ready-made code
-        * Introduce **events** & **keycodes** 
-        * Working with **matrices** 
-        * Your first view of the world of games :) 
-
-        ## An overview of what is already in the code
-        _If you're confortable with figuring out what the helper code does on your own, you can skip this bit._
-
-        * We have some notion of how we are going to start off this game. In this simple implementation, we'll be modelling the snake game by a 8x8 matrix. **What is a matrix?** Simply put, just an array of arrays, all of the same size. That means, an array `playMatrix` containing 8 arrays, each with 8 elements of their own. This gives us 64 little cells where our snake can run freely (_obviously without biting its tail_)  
-
-        ```js
-        /* How the state will be started initially */
-        getInitialState(){
-            const initialState = {
-              playMatrix: [
-                [0,0,0,0,0,0,0,0],
-                [0,0,0,0,0,0,0,0],
-                [0,0,0,0,0,0,0,0],
-                [0,0,0,0,0,0,0,0],
-                [0,0,0,0,0,0,0,0],
-                [0,0,0,0,0,0,0,0],
-                [0,0,0,0,0,0,0,0],
-                [0,0,0,0,0,0,0,0],
-              ],
-              snake: [],
-              currentDirection: 'up',
-              isGameActive: false,
-            }
-            return initialState;
-          }
-        ```
-        * Our snake starts off in the 'up' direction, we could have chosen any other one. (_The ones I've defined here are `'up'`, `'down'`, `'left`, `'right'` but you can very well name yours whatever, as long as you're consistent - i.e whenever you use them you make sure you know what each name stands for)_
-
-        * Pay close attention to the snake array. What should it be when it starts having values? Ideally, we'd like it to contain **positions**. How will these positions look? They should be just plain **objects** with `row` and `col` properties, to mimic matrix cells, which generally look like `playMatrix[row][col]`. More on this later. 
-
-        * We also have a notion of whetver or not we're actually playing the game, which makes sense in the context of displaying the `Start` button or not. This behaviour is exhibited in the code below: 
-        ```js
-        renderSnakeGame(){
-            if(this.state.isGameActive)
-              return this.drawSnakeGame()
-            else 
-              return <button className="Button" onClick={()=>this.startGame()}>Start</button>
-          }
-        ```
-
-        ...
-      """)
+      workshop.notes
     )
   }
 
-  var furtherReading: Node {
-    // TODO: Use actual data for this
-    let furtherReadingLinks = [
-      Link(
-        text: "Kitura Website",
-        url: URL(string: "http://www.kitura.io")!
-      ),
-      Link(
-        text: "The answer to all your troubles",
-        url: URL(string: "http://www.kitura.io")!
-      ),
-      Link(
-        text: "Someone's blog",
-        url: URL(string: "http://www.kitura.io")!
+  var furtherReading: Node? {
+    if workshop.furtherReadingLinks.isEmpty {
+      return nil
+    } else {
+      return El.Div[Attr.className => "WorkshopFurtherReading"].containing(
+        El.H1[Attr.className => "Text--sectionHeading"].containing("Further reading"),
+        El.Ul.containing(
+          workshop.furtherReadingLinks.map {
+            El.A[Attr.href => $0.url.absoluteString].containing(
+              El.Li.containing($0.text)
+            )
+          }
+        )
       )
-    ]
-
-    return El.Div[Attr.className => "WorkshopFurtherReading"].containing(
-      El.H1[Attr.className => "Text--sectionHeading"].containing("Further reading"),
-      El.Ul.containing(
-        furtherReadingLinks.map {
-          El.A[Attr.href => $0.url.absoluteString].containing(
-            El.Li.containing($0.text)
-          )
-        }
-      )
-    )
+    }
   }
 }

--- a/Sources/HaCWebsiteLib/Views/Workshops/WorkshopsIndexPage/WorkshopsIndexArchive.swift
+++ b/Sources/HaCWebsiteLib/Views/Workshops/WorkshopsIndexPage/WorkshopsIndexArchive.swift
@@ -1,0 +1,21 @@
+import HaCTML
+
+/// Above-the-fold for the WorkshopsIndexPage
+struct WorkshopsIndexArchive: Nodeable {
+  let workshops: [NewWorkshop]
+
+  var node: Node {
+    return El.Div[Attr.className => "WorkshopsIndexPage__archive"].containing(
+      El.H2[Attr.className => "Text--sectionHeading"].containing("Browse Workshops"),
+      El.Ul[Attr.className => "WorkshopsIndexPage__archive__list"].containing(
+        workshops.map { workshop in 
+          El.Li.containing(
+            El.A[Attr.href => "/beta/workshops/\(workshop.workshopId)", Attr.className => "WorkshopsIndexPage__archive__list__item"].containing( 
+              workshop.title
+            )
+          )
+        }
+      )
+    )
+  }
+}

--- a/Sources/HaCWebsiteLib/Views/Workshops/WorkshopsIndexPage/WorkshopsIndexPage.swift
+++ b/Sources/HaCWebsiteLib/Views/Workshops/WorkshopsIndexPage/WorkshopsIndexPage.swift
@@ -4,8 +4,7 @@ import HaCTML
 
 struct WorkshopsIndexPage {
 
-  let upcomingWorkshops: [PostCard]
-  let previousWorkshops: [PostCard]
+  let allWorkshops: [NewWorkshop]
 
   let demonstratorsGroupUrl = "https://www.facebook.com/groups/1567785333234852/"
 
@@ -15,16 +14,10 @@ struct WorkshopsIndexPage {
       content: El.Div[Attr.className => "WorkshopsIndexPage"].containing(
         BackBar(backLinkText: "Home", backLinkURL: "/"),
         WorkshopsIndexAbout(),
-        WorkshopsIndexSchedule(),
+        WorkshopsIndexArchive(workshops: allWorkshops),
+        // WorkshopsIndexSchedule(),
         WorkshopsIndexGetInvolved()
       )
     ).node
-  }
-
-  private var previous: Node {
-    return El.Div[Attr.className => "WorkshopsPrevious"].containing(
-      El.H1[Attr.className => "Text--sectionHeading"].containing("Previous"),
-      El.Div[Attr.className => "WorkshopsPrevious__cards"].containing(previousWorkshops)
-    )
   }
 }

--- a/Sources/HaCWebsiteLib/routes.swift
+++ b/Sources/HaCWebsiteLib/routes.swift
@@ -45,7 +45,7 @@ func getWebsiteRouter() -> Router {
   // MARK: Features in progress
   router.get("/beta/landing-update-feed", handler: LandingUpdateFeedController.handler)
   router.get("/beta/workshops", handler: WorkshopsController.handler)
-  router.get("/beta/workshops/intro-to-swift", handler: WorkshopsController.workshopHandler)
+  router.get("/beta/workshops/:workshopId", handler: WorkshopsController.workshopHandler)
 
   router.all("/", middleware: NotFoundMiddleware())
   router.error(ErrorRoutingMiddleware())

--- a/static/src/styles/WorkshopsIndex/WorkshopsIndexArchive.styl
+++ b/static/src/styles/WorkshopsIndex/WorkshopsIndexArchive.styl
@@ -1,0 +1,28 @@
+.WorkshopsIndexPage__archive {
+  max-width: 60em;
+  margin: 0 auto;
+  padding: grid(2);
+}
+
+.WorkshopsIndexPage__archive__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;  
+}
+
+.WorkshopsIndexPage__archive__list__item {
+  display: inline-block;
+  padding: 0.5em 1em;
+  margin-bottom: 1em;
+  border-radius: $Layout__normalBorderRadius;
+  background: white;
+  box-shadow: 0px 2px 6px alpha(darken(white, 50%), 0.3);
+  text-decoration: none;
+  color: inherit;
+  transition: background 0.2s;
+  width: 100%;
+}
+
+.WorkshopsIndexPage__archive__list__item:hover {
+  background: darken(white, 5%);
+}

--- a/static/src/styles/WorkshopsIndex/index.styl
+++ b/static/src/styles/WorkshopsIndex/index.styl
@@ -3,3 +3,4 @@
 @require './WorkshopsIndexGetInvolved';
 @require './WorkshopsIndexSchedule';
 @require './WorkshopsIndexUpcoming';
+@require './WorkshopsIndexArchive';


### PR DESCRIPTION
Fixes #197 

- Plugs in the IndividualWorkshopPage view to the given data
- Plugs in the WorkshopsIndexPage to available data by removing the events schedule and replaced with a workshops archive for now. The schedule should be reintroduced later.

<img width="719" alt="screen shot 2018-01-17 at 15 02 23" src="https://user-images.githubusercontent.com/3105017/35049308-769418f6-fb97-11e7-8e60-e4d9ce0d32e3.png">
