### PR TITLE
Add relative URL resolution to Markdown

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -281,6 +281,15 @@
         }
       },
       {
+        "package": "Regex",
+        "repositoryURL": "https://github.com/sharplet/Regex",
+        "state": {
+          "branch": null,
+          "revision": "3e671ed911b467c0d9c05e56f03d9e5bcb535f39",
+          "version": "1.1.0"
+        }
+      },
+      {
         "package": "Routing",
         "repositoryURL": "https://github.com/vapor/routing.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,8 @@ let package = Package(
     .package(url: "https://github.com/alexaubry/HTMLString", .upToNextMinor(from: "3.0.0")),
     .package(url: "https://github.com/vapor/fluent.git", .upToNextMinor(from: "2.4.0")),
     .package(url: "https://github.com/vapor-community/postgresql-driver.git", .upToNextMinor(from: "2.1.0")),
-    .package(url: "https://github.com/IBM-Swift/Kitura-CredentialsHTTP.git", .upToNextMinor(from: "2.0.0"))
+    .package(url: "https://github.com/IBM-Swift/Kitura-CredentialsHTTP.git", .upToNextMinor(from: "2.0.0")),
+    .package(url: "https://github.com/sharplet/Regex", .upToNextMajor(from: "1.1.0"))
   ],
   targets: [
     .target(name: "HaCTML", dependencies: [
@@ -37,7 +38,8 @@ let package = Package(
       "HTMLString",
       "Fluent",
       "PostgreSQLDriver",
-      "CredentialsHTTP"
+      "CredentialsHTTP",
+      "Regex"
     ]),
     .target(name: "HaCWebsite", dependencies: [
       "HaCWebsiteLib"

--- a/Sources/HaCWebsiteLib/Markdown+relativeURLs.swift
+++ b/Sources/HaCWebsiteLib/Markdown+relativeURLs.swift
@@ -1,0 +1,48 @@
+import Regex
+import Foundation
+
+extension Markdown {
+  /*
+   * Markdown references (links and images) can contain relative URLs
+   * This method will resolve relative URLs relative to a given base
+   * e.g. '[Meow](images/cat.png)' -> '[Meow](https://hackersatcambridge.com/images/cat.png)'
+   */ 
+  mutating func resolveRelativeURLs(relativeTo baseURL: URL) {
+
+    // See https://regexr.com/3jh10 for demo of this regex
+    let referenceTitleRegexString = 
+      "\\[" + // Opening '['
+      "([^\\[\\]]*?)" + // Capture 1: The optional reference title
+      "]" // Closing ']'
+
+    let referenceURLRegexString =
+      "\\(" + // Opening '('
+      "([^)]*?)" + // Capture 2: The URL
+      "\\)" // Closing ')'
+
+    let referenceRegexString =
+      "(!?)" +  // Capture 0: The optional '!' to indicate image references
+      referenceTitleRegexString +
+      referenceURLRegexString
+
+    let referenceRegex = try! Regex(string: referenceRegexString)
+    let referenceMatches = referenceRegex.allMatches(in: raw).sorted {
+      // Sort matches from back to front so that we don't mess up ranges as we make replacements
+      $0.range.lowerBound > $1.range.lowerBound
+    }
+    
+    var translatedRaw = raw
+    for match in referenceMatches {
+      // Get the url
+      let exclamationPoint = match.captures[0]!
+      let title = match.captures[1]!
+      let url = match.captures[2]!
+
+      let translatedURL = URL(string: url, relativeTo: baseURL)?.absoluteString ?? ""
+      let translatedReference = "\(exclamationPoint)[\(title)](\(translatedURL))"
+      translatedRaw.replaceSubrange(match.range, with: translatedReference)
+    }
+
+    raw = translatedRaw
+  }
+}

--- a/Sources/HaCWebsiteLib/Markdown+relativeURLs.swift
+++ b/Sources/HaCWebsiteLib/Markdown+relativeURLs.swift
@@ -6,6 +6,7 @@ extension Markdown {
    * Markdown references (links and images) can contain relative URLs
    * This method will resolve relative URLs relative to a given base
    * e.g. '[Meow](images/cat.png)' -> '[Meow](https://hackersatcambridge.com/images/cat.png)'
+   * Note: Does not handle commented or nested references (see #208)
    */ 
   func resolveRelativeURLs(relativeTo baseURL: URL) -> Markdown {
 

--- a/Sources/HaCWebsiteLib/Markdown+relativeURLs.swift
+++ b/Sources/HaCWebsiteLib/Markdown+relativeURLs.swift
@@ -7,7 +7,7 @@ extension Markdown {
    * This method will resolve relative URLs relative to a given base
    * e.g. '[Meow](images/cat.png)' -> '[Meow](https://hackersatcambridge.com/images/cat.png)'
    */ 
-  mutating func resolveRelativeURLs(relativeTo baseURL: URL) {
+  func resolveRelativeURLs(relativeTo baseURL: URL) -> Markdown {
 
     // See https://regexr.com/3jh10 for demo of this regex
     let referenceTitleRegexString = 
@@ -33,7 +33,6 @@ extension Markdown {
     
     var translatedRaw = raw
     for match in referenceMatches {
-      // Get the url
       let exclamationPoint = match.captures[0]!
       let title = match.captures[1]!
       let url = match.captures[2]!
@@ -43,6 +42,6 @@ extension Markdown {
       translatedRaw.replaceSubrange(match.range, with: translatedReference)
     }
 
-    raw = translatedRaw
+    return Markdown(translatedRaw)
   }
 }

--- a/Sources/HaCWebsiteLib/Markdown.swift
+++ b/Sources/HaCWebsiteLib/Markdown.swift
@@ -3,7 +3,7 @@ import HaCTML
 
 /// A type for text in Markdown form
 struct Markdown {
-  let raw: String
+  var raw: String
 
   init(_ markdown: String) {
     raw = markdown

--- a/Sources/HaCWebsiteLib/Markdown.swift
+++ b/Sources/HaCWebsiteLib/Markdown.swift
@@ -3,7 +3,7 @@ import HaCTML
 
 /// A type for text in Markdown form
 struct Markdown {
-  var raw: String
+  let raw: String
 
   init(_ markdown: String) {
     raw = markdown

--- a/Sources/HaCWebsiteLib/Models/NewWorkshop+init.swift
+++ b/Sources/HaCWebsiteLib/Models/NewWorkshop+init.swift
@@ -193,11 +193,9 @@ private struct WorkshopBuilder {
   }
 
   func getNotes() throws -> Markdown {
-    // TODO(#192): Handle embedded images in notes.md
     do {
-      var notes = try Markdown(contentsOfFile: localPath + filePaths.notesMarkdown)
-      notes.resolveRelativeURLs(relativeTo: try fileservingUrl(relativePath: filePaths.notesMarkdown))
-      return notes
+      let notes = try Markdown(contentsOfFile: localPath + filePaths.notesMarkdown)
+      return notes.resolveRelativeURLs(relativeTo: try fileservingUrl(relativePath: filePaths.notesMarkdown))
     } catch {
       throw WorkshopError.missingNotes
     }

--- a/Sources/HaCWebsiteLib/Models/NewWorkshop+init.swift
+++ b/Sources/HaCWebsiteLib/Models/NewWorkshop+init.swift
@@ -195,7 +195,9 @@ private struct WorkshopBuilder {
   func getNotes() throws -> Markdown {
     // TODO(#192): Handle embedded images in notes.md
     do {
-      return try Markdown(contentsOfFile: localPath + filePaths.notesMarkdown)
+      var notes = try Markdown(contentsOfFile: localPath + filePaths.notesMarkdown)
+      notes.resolveRelativeURLs(relativeTo: try fileservingUrl(relativePath: filePaths.notesMarkdown))
+      return notes
     } catch {
       throw WorkshopError.missingNotes
     }

--- a/Tests/HaCWebsiteLibTests/MarkdownTests.swift
+++ b/Tests/HaCWebsiteLibTests/MarkdownTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import HaCWebsiteLib
+
+class MarkdownTests: HaCWebsiteLibTestCase {
+  func testAbsoluteOnly() throws {
+    var markdown = Markdown(try getTestResourceString(from: "MarkdownRelativeURLTestData/absolute_only.md"))
+    markdown.resolveRelativeURLs(relativeTo: URL(string: "https://test.com")!)
+
+    XCTAssertEqual(markdown.raw,
+      """
+      This is a test
+
+      Here's a link to somewhere else [Clickme](https://hackersatcambridge.com)
+
+      ![Flower Pot Men](https://upload.wikimedia.org/wikipedia/en/c/c6/%22Flower_Pot_Men%22.jpg)
+
+      Hello hello
+      """
+    )
+  }
+
+  func testSomeRelative() throws {
+    var markdown = Markdown(try getTestResourceString(from: "MarkdownRelativeURLTestData/some_relative.md"))
+    markdown.resolveRelativeURLs(relativeTo: URL(string: "https://test.com/stuff/test.html")!)
+
+    XCTAssertEqual(markdown.raw,
+      """
+      This is a test
+
+      Here's a link to somewhere else [Clickme](https://hackersatcambridge.com)
+
+      ![Flower Pot Men](https://test.com/stuff/assets/billben.jpg)
+
+      Hello hello
+      """
+    )
+  }
+
+  func testBracketing() throws {
+    var markdown = Markdown(try getTestResourceString(from: "MarkdownRelativeURLTestData/brackets.md"))
+    markdown.resolveRelativeURLs(relativeTo: URL(string: "https://test.com")!)
+
+    XCTAssertEqual(markdown.raw,
+      """
+      This is a test
+
+      Here's a link to somewhere else [Clickme](https://hackersatcambridge.com))
+
+      [![Flower Pot Men](https://test.com/assets/billben.jpg)]]
+
+      Hello hello
+      """
+    )
+  }
+
+  static var allTests : [(String, (MarkdownTests) -> () throws -> Void)] {
+    return [
+      ("testAbsoluteOnly", testAbsoluteOnly),
+      ("testSomeRelative", testSomeRelative),
+      ("testBracketing", testBracketing)
+    ]
+  }
+}

--- a/Tests/HaCWebsiteLibTests/Resources/MarkdownRelativeURLTestData/absolute_only.md
+++ b/Tests/HaCWebsiteLibTests/Resources/MarkdownRelativeURLTestData/absolute_only.md
@@ -1,0 +1,7 @@
+This is a test
+
+Here's a link to somewhere else [Clickme](https://hackersatcambridge.com)
+
+![Flower Pot Men](https://upload.wikimedia.org/wikipedia/en/c/c6/%22Flower_Pot_Men%22.jpg)
+
+Hello hello

--- a/Tests/HaCWebsiteLibTests/Resources/MarkdownRelativeURLTestData/brackets.md
+++ b/Tests/HaCWebsiteLibTests/Resources/MarkdownRelativeURLTestData/brackets.md
@@ -1,0 +1,7 @@
+This is a test
+
+Here's a link to somewhere else [Clickme](https://hackersatcambridge.com))
+
+[![Flower Pot Men](assets/billben.jpg)]]
+
+Hello hello

--- a/Tests/HaCWebsiteLibTests/Resources/MarkdownRelativeURLTestData/some_relative.md
+++ b/Tests/HaCWebsiteLibTests/Resources/MarkdownRelativeURLTestData/some_relative.md
@@ -1,0 +1,7 @@
+This is a test
+
+Here's a link to somewhere else [Clickme](https://hackersatcambridge.com)
+
+![Flower Pot Men](assets/billben.jpg)
+
+Hello hello

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -5,4 +5,5 @@ XCTMain([
   testCase(WorkshopTests.allTests),
   testCase(DateUtilsTests.allTests),
   testCase(NewWorkshopTests.allTests),
+  testCase(MarkdownTests.allTests),
 ])


### PR DESCRIPTION
Fixes #192 

Adds support for images at relative URLs in notes by resolving relative URLs at the import stage.