### PR TITLE
Use Fluent to automatically run migrations

### DIFF
--- a/Sources/HaCWebsiteLib/DatabasePreparations.swift
+++ b/Sources/HaCWebsiteLib/DatabasePreparations.swift
@@ -1,0 +1,14 @@
+enum DatabasePreparations {
+  /**
+    A list of preparations to run, in order, to bring the database to a state
+    that is usable on the current codebase.
+
+    ADD NEW PREPARATIONS TO THE END OF THIS LIST
+
+    Preparation is a migration in Fluent (our ORM). Read more on preparations:
+      https://docs.vapor.codes/2.0/fluent/database/#preparations
+   */
+  static let preparations = [
+    GeneralEvent.InitPreparation.self,
+  ]
+}

--- a/Sources/HaCWebsiteLib/Events/GeneralEvent.swift
+++ b/Sources/HaCWebsiteLib/Events/GeneralEvent.swift
@@ -96,30 +96,32 @@ final class GeneralEvent: Event, Entity {
   }
 }
 
-extension GeneralEvent: Preparation {
-  static func prepare(_ database: Database) throws {
-    try database.create(self) { events in 
-      events.id()
-      events.string("title")
-      events.date("startDate")
-      events.date("endDate")
-      events.string("tagLine")
-      events.string("color")
-      events.date("hypeStartDate")
-      events.date("hypeEndDate")
-      events.custom("tags", type: "TEXT[]")
-      events.string("markdown")
-      events.string("websiteURL", optional: true)
-      events.string("imageURL", optional: true)
-      events.double("latitude", optional: true)
-      events.double("longitude", optional: true)
-      events.string("address", optional: true)
-      events.string("venue", optional: true)
-      events.string("facebookEventID", optional: true)
+extension GeneralEvent {
+  enum InitPreparation: Preparation {
+    static func prepare(_ database: Database) throws {
+      try database.create(GeneralEvent.self) { events in 
+        events.id()
+        events.string("title")
+        events.date("startDate")
+        events.date("endDate")
+        events.string("tagLine")
+        events.string("color")
+        events.date("hypeStartDate")
+        events.date("hypeEndDate")
+        events.custom("tags", type: "TEXT[]")
+        events.string("markdown")
+        events.string("websiteURL", optional: true)
+        events.string("imageURL", optional: true)
+        events.double("latitude", optional: true)
+        events.double("longitude", optional: true)
+        events.string("address", optional: true)
+        events.string("venue", optional: true)
+        events.string("facebookEventID", optional: true)
+      }
     }
-  }
 
-  static func revert(_ database : Database) throws {
-    try database.delete(self)
+    static func revert(_ database : Database) throws {
+      try database.delete(GeneralEvent.self)
+    }
   }
 }

--- a/Sources/HaCWebsiteLib/Utils/DatabaseUtils.swift
+++ b/Sources/HaCWebsiteLib/Utils/DatabaseUtils.swift
@@ -10,10 +10,6 @@ struct DatabaseURLComponents {
   let database: String
 }
 
-private let preparations = [
-  GeneralEvent.self
-]
-
 extension URL {
   var databaseURLComponents: DatabaseURLComponents? {
     if let host = self.host,

--- a/Sources/HaCWebsiteLib/Utils/DatabaseUtils.swift
+++ b/Sources/HaCWebsiteLib/Utils/DatabaseUtils.swift
@@ -10,6 +10,10 @@ struct DatabaseURLComponents {
   let database: String
 }
 
+private let preparations = [
+  GeneralEvent.self
+]
+
 extension URL {
   var databaseURLComponents: DatabaseURLComponents? {
     if let host = self.host,
@@ -20,7 +24,7 @@ extension URL {
           host: host,
           user: user,
           password: password,
-          database: String(path.characters.dropFirst())
+          database: String(path.dropFirst())
         )
     } else {
       return nil
@@ -29,12 +33,12 @@ extension URL {
 }
 
 enum DatabaseUtils {
-  public static func prepareDatabase() {
+  public static func prepareDatabase(withPreparations: [Preparation.Type]) {
     do {
       let driver = try getDatabaseDriver()
       let database = Database(driver)
       Database.default = database
-      try GeneralEvent.prepare(database)
+      try database.prepare(withPreparations)
     } catch {
       print("Failed to prepare database")
     }

--- a/Sources/HaCWebsiteLib/routes.swift
+++ b/Sources/HaCWebsiteLib/routes.swift
@@ -58,7 +58,7 @@ func getWebsiteRouter() -> Router {
 }
 
 public func serveWebsite() {
-  DatabaseUtils.prepareDatabase()
+  DatabaseUtils.prepareDatabase(withPreparations: DatabasePreparations.preparations)
   // Helium logger provides logging for Kitura processes
   HeliumLogger.use()
   // This speaks to Kitura's 'LoggerAPI' to set the default logger to HeliumLogger.


### PR DESCRIPTION
This uses Fluent built-in preparation manager to handle preparations (so they only run once). Previously we were managing this on our own.

I've verified that preparations successfully run, and do not re-run or error when they have already run.

We will need to nuke the DB in prod before this is shipped, but there is no useful data up there.

@CharlieCrisp could you validate that what I am doing is OK?