### PR TITLE
Fix issues with deployment and add production build to tests

### DIFF
--- a/Sources/HaCWebsiteLib/Assets.swift
+++ b/Sources/HaCWebsiteLib/Assets.swift
@@ -85,7 +85,7 @@ private struct AssetResolver {
 
 private func omitLeadingSlash(_ string: String) -> String {
   if (string[string.startIndex] == "/") {
-    return string.substring(from: string.index(after: string.startIndex))
+    return String(string[string.index(after: string.startIndex)...])
   }
 
   return string

--- a/Sources/HaCWebsiteLib/DatabasePreparations.swift
+++ b/Sources/HaCWebsiteLib/DatabasePreparations.swift
@@ -1,3 +1,5 @@
+import Fluent
+
 enum DatabasePreparations {
   /**
     A list of preparations to run, in order, to bring the database to a state
@@ -8,7 +10,7 @@ enum DatabasePreparations {
     Preparation is a migration in Fluent (our ORM). Read more on preparations:
       https://docs.vapor.codes/2.0/fluent/database/#preparations
    */
-  static let preparations = [
+  static let preparations: [Preparation.Type] = [
     GeneralEvent.InitPreparation.self,
   ]
 }

--- a/Sources/HaCWebsiteLib/routes.swift
+++ b/Sources/HaCWebsiteLib/routes.swift
@@ -6,8 +6,6 @@ import SwiftyJSON
 import LoggerAPI
 import HeliumLogger
 import HaCTML
-import Fluent
-import PostgreSQLDriver
 
 func getWebsiteRouter() -> Router {
   let router = Router()

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "The official website of Cambridge's technology society",
   "main": "index.js",
   "scripts": {
-    "test": "swift test | perl -pe 's/(Test Case .*passed.*)/✅ \\1/' | perl -pe 's/(Test Case .* failed.*)/🆘 \\1/'",
+    "test": "yarn test:production-build && yarn test:run-tests",
+    "test:run-tests": "swift test | perl -pe 's/(Test Case .*passed.*)/✅ \\1/' | perl -pe 's/(Test Case .* failed.*)/🆘 \\1/'",
+    "test:production-build": "swift build -c release",
     "gulp": "gulp",
     "heroku-postbuild": "gulp static-build"
   },


### PR DESCRIPTION
This fixes the cryptic error we were getting from Heroku. It was due to the lack of type annotation on `DatabasePreparations.preparations`. It should have been a type error, but was instead crashing the compiler (only in release configuration).

To help us prevent these issues from happening in the future, I've added a production build to our test suite. It adds time to our travis build unfortunately, but it reduces the difference between our test environment and production.

I've also fixed up a deprecation warning we were getting, but that's unrelated (in Assets)