### PR TITLE
Optional fields

### DIFF
--- a/Sources/HaCWebsiteLib/Models/Workshop+init.swift
+++ b/Sources/HaCWebsiteLib/Models/Workshop+init.swift
@@ -71,6 +71,7 @@ private enum WorkshopError: Swift.Error {
   case missingPrerequisites
   case missingPromoImageBackground
   case missingPromoImageForeground
+  case missingMetadataKey(String)
   case multiplePromoImageForegrounds
   case multiplePromoImageBackgrounds
   case invalidPromoImageForegroundFormat
@@ -214,7 +215,11 @@ private struct WorkshopBuilder {
   }
 
   func getThanks() throws -> [String] {
-    return try stringsArray(for: "thanks", in: metadata)
+    do {
+      return try stringsArray(for: "thanks", in: metadata)
+    } catch WorkshopError.missingMetadataKey(_) {
+      return []
+    }
   }
 
   func getFurtherReadingLinks() throws -> [Link] {
@@ -283,7 +288,7 @@ private func getFileExtension(fromPath filePath: String) -> String? {
 
 private func stringsArray(for key: Yaml, in metadata: Yaml) throws -> [String] {
   guard let values = metadata[key].array else {
-    throw WorkshopError.malformedMetadata("Missing \(key) list")
+    throw WorkshopError.missingMetadataKey("Missing \(key) list")
   }
 
   return try values.map({

--- a/Sources/HaCWebsiteLib/Models/Workshop+init.swift
+++ b/Sources/HaCWebsiteLib/Models/Workshop+init.swift
@@ -224,7 +224,7 @@ private struct WorkshopBuilder {
 
   func getFurtherReadingLinks() throws -> [Link] {
     guard let links = metadata["further_reading_links"].array else {
-      throw WorkshopError.malformedMetadata("Missing further reading links")
+      return []
     }
     return try links.map({
       guard let text = $0["text"].string,

--- a/Tests/HaCWebsiteLibTests/Resources/WorkshopTestData/workshop-missing-tags/info/metadata.yaml
+++ b/Tests/HaCWebsiteLibTests/Resources/WorkshopTestData/workshop-missing-tags/info/metadata.yaml
@@ -4,7 +4,7 @@ title: Sample Workshop
 contributors: []
 
 # A set of keywords associated with the workshop
-tags: []
+# tags: []
 
 # A license code by which the workshop content is released
 license: MIT


### PR DESCRIPTION
Makes `thanks` and `further_reading_links` fields of workshop metadata files optional, modelling them as empty lists in Swift when they are omitted from the Yaml file.