### PR TITLE
Add workshop syntax highlighting

### DIFF
--- a/Sources/HaCWebsiteLib/Views/Hackathons/GameGig2017/GameGig2017.swift
+++ b/Sources/HaCWebsiteLib/Views/Hackathons/GameGig2017/GameGig2017.swift
@@ -186,7 +186,7 @@ struct GameGig2017: Hackathon {
 
     return Page(
       title: "Hackers at Cambridge Game Gig 80's",
-      customStylesheets: ["gamegig2017"],
+      postFixElements: Page.stylesheet(forUrl: Assets.publicPath("/styles/custom/gamegig2017.css")),
       content: Fragment(
         El.Div[Attr.className => "GameGigHero"].containing(
           El.Img[Attr.className => "GameGigHero__image", Attr.src => Assets.publicPath("/images/gamegig3000/gamegig-foreground.png")]

--- a/Sources/HaCWebsiteLib/Views/Page.swift
+++ b/Sources/HaCWebsiteLib/Views/Page.swift
@@ -3,15 +3,15 @@ import Foundation
 
 struct Page: Nodeable {
   let title: String
-  let customStylesheets: [String]
+  let postFixElements: Nodeable
   let content: Nodeable
 
-  init(title: String = defaultTitle, customStylesheets: [String] = [], content: Nodeable) {
+  init(title: String = defaultTitle, postFixElements: Nodeable = Fragment(), content: Nodeable) {
     self.title = title
-    self.customStylesheets = customStylesheets
+    self.postFixElements = postFixElements
     self.content = content
   }
-  
+
   public var node: Node {
     return Fragment(
       El.Doctype,
@@ -22,7 +22,7 @@ struct Page: Nodeable {
           El.Link[Attr.rel => "icon", Attr.type => "favicon/png", Attr.href => Assets.publicPath("/images/favicon.png")],
           El.Title.containing(title),
           Page.stylesheet(forUrl: Assets.publicPath("/styles/main.css")),
-          Fragment(customStylesheets.map { Page.stylesheet(forUrl: Assets.publicPath("/styles/custom/\($0).css")) })
+          postFixElements
         )
       ),
       El.Body.containing(
@@ -52,7 +52,7 @@ struct Page: Nodeable {
 
   private static let defaultTitle = "Cambridge's student tech society | Hackers at Cambridge"
 
-  private static func stylesheet(forUrl urlString: String) -> Node {
+  public static func stylesheet(forUrl urlString: String) -> Node {
     return El.Link[Attr.rel => "stylesheet", Attr.type => "text/css", Attr.href => urlString]
   }
 }

--- a/Sources/HaCWebsiteLib/Views/Workshops/IndividualWorkshopPage.swift
+++ b/Sources/HaCWebsiteLib/Views/Workshops/IndividualWorkshopPage.swift
@@ -9,6 +9,14 @@ struct IndividualWorkshopPage {
   var node: Node {
     return Page(
       title: "\(workshop.title) | Hackers at Cambridge",
+      // Use hightlight js to syntax-highlight code that appears in workshop notes https://highlightjs.org
+      postFixElements: Fragment(
+        Page.stylesheet(forUrl: "//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/default.min.css"),
+        El.Script[Attr.src => "//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"],
+        El.Script[Attr.src => "//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.4.0/languages/groovy.min.js"],
+        El.Script[Attr.src => "//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.4.0/languages/gradle.min.js"],
+        El.Script.containing("hljs.initHighlightingOnLoad();")
+      ),
       content: Fragment(
         BackBar(backLinkText: "Workshops", backLinkURL: "/workshops"),
         hero, // A big beautiful header


### PR DESCRIPTION
Fixes #221  .

Previously
![image](https://user-images.githubusercontent.com/10348641/35807935-297cf8d2-0a7c-11e8-95fe-64cddea8cfa8.png)

Now
![image](https://user-images.githubusercontent.com/10348641/35879569-73cb50c6-0b73-11e8-90cc-f000c4d9d95b.png)

This change also allows for general postFix changes on pages as well.
