### PR TITLE
Add a workshop validation route

### DIFF
--- a/Sources/HaCWebsiteLib/Controllers/WorkshopsController.swift
+++ b/Sources/HaCWebsiteLib/Controllers/WorkshopsController.swift
@@ -1,4 +1,5 @@
 import Kitura
+import HaCTML
 
 struct WorkshopsController {
 
@@ -28,6 +29,69 @@ struct WorkshopsController {
     try response.send(
       "Workshops updated!"
     ).end()
+  }
+
+  static var workshopVerifyHandler: RouterHandler = { request, response, next in
+    if let workshopId = request.parameters["workshopId"] {
+      let workshopURL = "https://github.com/hackersatcambridge/workshop-\(workshopId)"
+      // Pull the repo to /test/id repo
+      // Run the parser
+      // Spit out the errors, or the workshop page if no errors
+      let repoUtil = GitUtil(
+        remoteRepoURL: workshopURL,
+        directoryName: "workshop-\(workshopId)"
+      )
+      print("Updating repo...")
+      repoUtil.update()
+      print("Finished updating")
+
+      let errorNode: Nodeable?
+      let pageNode: Nodeable?
+
+      do {
+        let workshop = try Workshop(localPath: repoUtil.localRepoPath, headCommitSha: repoUtil.getHeadCommitSha())
+
+        // MARK: Add warnings that probably indicate mistakes but are not validation errors
+        var warnings: [String] = []
+        if workshop.title == "Sample Workshop" { warnings.append("Title has not been set") }
+        if workshop.contributors.isEmpty { warnings.append("Contributors have not been listed") }
+
+        if warnings.isEmpty {
+          errorNode = El.Div[
+            Attr.className => "FlashMessage FlashMessage--positive"
+          ].containing(
+            "Valid workshop repo!"
+          )
+        } else {
+          errorNode = El.Div[
+            Attr.className => "FlashMessage FlashMessage--minorNegative"
+          ].containing(
+            El.Ul.containing(
+              warnings.map {
+                El.Li.containing("warning: \($0)")
+              }
+            )
+          )
+        }
+
+        pageNode = IndividualWorkshopPage(workshop: workshop)
+
+      } catch {
+        errorNode = El.Div[Attr.className => "FlashMessage FlashMessage--negative"].containing("error: \(error)")
+        pageNode = nil
+      }
+      try response.send(
+        Page(
+          title: "Workshop Validator: \(workshopId)",
+          content: Fragment([
+            errorNode,
+            pageNode 
+          ])
+        ).render()
+      ).end()
+    } else {
+      next()
+    }
   }
 
 }

--- a/Sources/HaCWebsiteLib/Controllers/WorkshopsController.swift
+++ b/Sources/HaCWebsiteLib/Controllers/WorkshopsController.swift
@@ -13,7 +13,7 @@ struct WorkshopsController {
     ).end()
   }
 
-  static var workshopHandler: RouterHandler = { request, response, next in 
+  static var workshopHandler: RouterHandler = { request, response, next in
     if let workshopId = request.parameters["workshopId"],
       let workshop = WorkshopManager.workshops["workshop-\(workshopId)"] {
         try response.send(
@@ -34,7 +34,6 @@ struct WorkshopsController {
   static var workshopVerifyHandler: RouterHandler = { request, response, next in
     if let workshopId = request.parameters["workshopId"] {
       let workshopURL = "https://github.com/hackersatcambridge/workshop-\(workshopId)"
-      // Pull the repo to /test/id repo
       // Run the parser
       // Spit out the errors, or the workshop page if no errors
       let repoUtil = GitUtil(
@@ -85,7 +84,7 @@ struct WorkshopsController {
           title: "Workshop Validator: \(workshopId)",
           content: Fragment([
             errorNode,
-            pageNode 
+            pageNode
           ])
         ).render()
       ).end()

--- a/Sources/HaCWebsiteLib/Markdown.swift
+++ b/Sources/HaCWebsiteLib/Markdown.swift
@@ -9,8 +9,16 @@ struct Markdown {
     raw = markdown
   }
 
+  public enum Error: Swift.Error {
+    case initialisation(String)
+  }
+
   init(contentsOfFile filePath: String) throws {
-    self.init(try String(contentsOfFile: filePath, encoding: .utf8))
+    do {
+      self.init(try String(contentsOfFile: filePath, encoding: .utf8))
+    } catch {
+      throw Error.initialisation("Couldn't find (UTF8-encoded) file at \(filePath)")
+    }
   }
 
   var html: String {

--- a/Sources/HaCWebsiteLib/Models/Workshop+init.swift
+++ b/Sources/HaCWebsiteLib/Models/Workshop+init.swift
@@ -69,6 +69,7 @@ private enum WorkshopError: Swift.Error {
   case malformedMetadata(String)
   case missingDescription
   case missingPrerequisites
+  case missingSetupInstructions
   case missingPromoImageBackground
   case missingPromoImageForeground
   case missingMetadataKey(String)
@@ -105,7 +106,11 @@ private struct WorkshopBuilder {
   }
 
   func getSetupInstructions() throws -> Markdown {
-    return try Markdown(contentsOfFile: localPath + filePaths.setupInstructions)
+    do {
+      return try Markdown(contentsOfFile: localPath + filePaths.setupInstructions)
+    } catch {
+      throw WorkshopError.missingSetupInstructions
+    }
   }
 
   func getPresenterGuide() throws -> Markdown? {

--- a/Sources/HaCWebsiteLib/Views/Workshops/IndividualWorkshopPage.swift
+++ b/Sources/HaCWebsiteLib/Views/Workshops/IndividualWorkshopPage.swift
@@ -3,7 +3,7 @@ import Foundation
 
 // swiftlint:disable line_length
 
-struct IndividualWorkshopPage {
+struct IndividualWorkshopPage: Nodeable {
   let workshop: Workshop
 
   var node: Node {

--- a/Sources/HaCWebsiteLib/routes.swift
+++ b/Sources/HaCWebsiteLib/routes.swift
@@ -45,6 +45,8 @@ func getWebsiteRouter() -> Router {
   router.get("/workshops/:workshopId", handler: WorkshopsController.workshopHandler)
   router.get("/workshops/update", middleware: CredentialsServer.credentials)
   router.get("/workshops/update", handler: WorkshopsController.workshopUpdateHandler)
+  router.get("/workshops/validate/:workshopId", middleware: CredentialsServer.credentials)
+  router.get("/workshops/validate/:workshopId", handler: WorkshopsController.workshopVerifyHandler)
 
   router.all("/", middleware: NotFoundMiddleware())
   router.error(ErrorRoutingMiddleware())

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     environment:
       DATA_DIR: /root/hac-website/Data
       DATABASE_URL: postgres://richard:test@hac-db:5432/hac
+      API_PASSWORD: test
     volumes:
       - build:/root/hac-website/.build
       - node_modules:/root/hac-website/node_modules

--- a/static/src/styles/core/flash.styl
+++ b/static/src/styles/core/flash.styl
@@ -1,0 +1,20 @@
+.FlashMessage {
+  border: 2px solid;
+  padding: 1em;
+  font-family: $Text__codeFont;
+}
+
+.FlashMessage--positive {
+  border-color: #87C639;
+  background: alpha(#87C639, 0.3);
+}
+
+.FlashMessage--minorNegative {
+  border-color: #C18E18;
+  background: alpha(#C18E18, 0.3);
+}
+
+.FlashMessage--negative {
+  border-color: #911A0C;
+  background: alpha(#911A0C, 0.3);
+}

--- a/static/src/styles/core/index.styl
+++ b/static/src/styles/core/index.styl
@@ -7,6 +7,7 @@
 @require './text';
 @require './interaction';
 @require './brand';
+@require './flash';
 
 .Error {
   margin: 20px;


### PR DESCRIPTION
Fixes #222 

Adds a route `/workshops/validate/:workshopId`
That parses the workshop repo at `github.com/hackersatcambridge/workshop-<workshopId>` and prints results for quick validation of workshop repos.

Screenshots (for frontend changes only):
Some results: 
<img width="503" alt="screen shot 2018-02-10 at 15 33 37" src="https://user-images.githubusercontent.com/3105017/36063666-d169078a-0e77-11e8-8d3f-107b14bb509a.png">
<img width="504" alt="screen shot 2018-02-10 at 15 34 18" src="https://user-images.githubusercontent.com/3105017/36063671-e040acea-0e77-11e8-80f0-897d6da64dd4.png">
<img width="505" alt="screen shot 2018-02-10 at 15 34 43" src="https://user-images.githubusercontent.com/3105017/36063676-ee6daef8-0e77-11e8-91a9-44dcbaf7e9cb.png">

There is an issue with this in the dev environment. Trying to validate a workshop where the repo doesn't exist will cause an indefinite request and subsequent reloads of the server in the dev environment will fail due to this request still holding the port open (as far as I can tell). This is due to the Git command requesting a username which can't be given so hangs.