### PR TITLE
Add License Button to Workshops

### DIFF
--- a/Sources/HaCWebsiteLib/Views/Workshops/IndividualWorkshopPage.swift
+++ b/Sources/HaCWebsiteLib/Views/Workshops/IndividualWorkshopPage.swift
@@ -81,6 +81,17 @@ struct IndividualWorkshopPage: Nodeable {
     }
   }
 
+  var licenseButton: Node? {
+    let licenseURL = workshop.license.isEmpty ? nil : URL(string: "https://github.com/hackersatcambridge/workshop-\(workshop.workshopId)/blob/master/LICENSE")
+    return licenseURL.map {
+      El.A[Attr.href => $0.absoluteString, Attr.target => "_blank"].containing(
+        El.Div[Attr.className => "BigButton BigButton--inline BigButton--license"].containing(
+          "License: " + workshop.license
+        )
+      )
+    }
+  }
+
   var examplesButton: Node? {
     return workshop.examplesLink.map {
       El.A[Attr.href => $0.absoluteString, Attr.target => "_blank"].containing(
@@ -93,7 +104,7 @@ struct IndividualWorkshopPage: Nodeable {
 
   var content: Node {
     return El.Div[Attr.className => "WorkshopContent"].containing(
-      slidesButton, recordingButton, examplesButton,
+      slidesButton, recordingButton, examplesButton, licenseButton,
       workshop.notes
     )
   }

--- a/static/src/styles/core/interaction.styl
+++ b/static/src/styles/core/interaction.styl
@@ -50,3 +50,11 @@
 .BigButton--github:hover {
   background: darken($Color__github, 20%);
 }
+
+.BigButton--license{
+  background: $Color__bright2;
+}
+
+.BigButton--license:hover{
+  background: darken($Color__bright2, 20%);
+}


### PR DESCRIPTION
Adding license button to the workshop pages with the format "License: " + SPDX Identifier which will take you to the GitHub License file for that particular workshop. Styling is just the "$Color__bright2". Resolving issue #235 . 

Previously
<img width="1024" alt="license_before" src="https://user-images.githubusercontent.com/20166594/36320293-9ccee9f2-133d-11e8-9bee-177443f8f7a2.png">


Now
<img width="1013" alt="license_after" src="https://user-images.githubusercontent.com/20166594/36320301-a43894cc-133d-11e8-888e-2aede892b9e9.png">
