### PR TITLE
Assume workshops repo uses workshopIDs not URLs

### DIFF
--- a/Sources/HaCWebsiteLib/Controllers/WorkshopsController.swift
+++ b/Sources/HaCWebsiteLib/Controllers/WorkshopsController.swift
@@ -15,7 +15,7 @@ struct WorkshopsController {
 
   static var workshopHandler: RouterHandler = { request, response, next in
     if let workshopId = request.parameters["workshopId"],
-      let workshop = WorkshopManager.workshops["workshop-\(workshopId)"] {
+      let workshop = WorkshopManager.workshops[workshopId] {
         try response.send(
           IndividualWorkshopPage(workshop: workshop).node.render()
         ).end()

--- a/Sources/HaCWebsiteLib/Views/LandingPage/LandingFeatures/ContinuousIntegrationWorkshop.swift
+++ b/Sources/HaCWebsiteLib/Views/LandingPage/LandingFeatures/ContinuousIntegrationWorkshop.swift
@@ -3,7 +3,7 @@ import Foundation
 
 extension LandingFeatures {
   static var continuousIntegrationWorkshop: LandingFeature? {
-    guard let hero = WorkshopManager.workshops["workshop-continuous-integration"]?.hero else {
+    guard let hero = WorkshopManager.workshops["continuous-integration"]?.hero else {
         return nil
     }
 

--- a/Sources/HaCWebsiteLib/Views/LandingPage/LandingFeatures/EmacsWorkshop.swift
+++ b/Sources/HaCWebsiteLib/Views/LandingPage/LandingFeatures/EmacsWorkshop.swift
@@ -3,7 +3,7 @@ import Foundation
 
 extension LandingFeatures {
   static var emacsWorkshop: LandingFeature? {
-    guard let hero = WorkshopManager.workshops["workshop-emacs"]?.hero else {
+    guard let hero = WorkshopManager.workshops["emacs"]?.hero else {
         return nil
     }
 

--- a/Sources/HaCWebsiteLib/Views/LandingPage/LandingFeatures/IntroToSwift.swift
+++ b/Sources/HaCWebsiteLib/Views/LandingPage/LandingFeatures/IntroToSwift.swift
@@ -3,7 +3,7 @@ import Foundation
 
 extension LandingFeatures {
   static var introToSwiftWorkshop: LandingFeature? {
-    guard let hero = WorkshopManager.workshops["workshop-intro-to-swift"]?.hero else {
+    guard let hero = WorkshopManager.workshops["intro-to-swift"]?.hero else {
         return nil
     }
 

--- a/Sources/HaCWebsiteLib/Views/LandingPage/LandingFeatures/OpenSourceWorkshop.swift
+++ b/Sources/HaCWebsiteLib/Views/LandingPage/LandingFeatures/OpenSourceWorkshop.swift
@@ -3,7 +3,7 @@ import Foundation
 
 extension LandingFeatures {
   static var openSourceWorkshop: LandingFeature? {
-    guard let hero = WorkshopManager.workshops["workshop-open-source"]?.hero else {
+    guard let hero = WorkshopManager.workshops["open-source"]?.hero else {
       return nil
     }
 

--- a/Sources/HaCWebsiteLib/Views/LandingPage/LandingFeatures/PythonML.swift
+++ b/Sources/HaCWebsiteLib/Views/LandingPage/LandingFeatures/PythonML.swift
@@ -3,7 +3,7 @@ import Foundation
 
 extension LandingFeatures {
   static var pythonML: LandingFeature? {
-    guard let hero = WorkshopManager.workshops["workshop-python-ml"]?.hero else {
+    guard let hero = WorkshopManager.workshops["python-ml"]?.hero else {
       return nil
     }
 


### PR DESCRIPTION
This change means that now the workshop manger indexes workshops by
their IDs instead of their repo names as well.

Fixes #243 and fixes #254 .
