### PR TITLE
Resize images in workshop to fit container

### DIFF
--- a/static/src/styles/Workshop/WorkshopContent.styl
+++ b/static/src/styles/Workshop/WorkshopContent.styl
@@ -4,4 +4,10 @@
   padding-top: grid(8);
   max-width: grid(120);
   margin: 0 auto;
+
+  // As the content is generated with Markdown, we cannot add classes
+  // to elements, so we must use a nested selector
+  img {
+    max-width: 100%;
+  }
 }

--- a/static/src/styles/Workshop/WorkshopDescription.styl
+++ b/static/src/styles/Workshop/WorkshopDescription.styl
@@ -2,6 +2,12 @@
   padding: grid(4);
   max-width: grid(120);
   margin: 0 auto;
+
+  // As the content is generated with Markdown, we cannot add classes
+  // to elements, so we must use a nested selector
+  img {
+    max-width: 100%;
+  }
 }
 
 .WorkshopDescription__detail {


### PR DESCRIPTION
Images in workshops were not being resized to fit their container, leading to big images being reeeeally big.

Screenshots (for frontend changes only):

Previously

![image](https://user-images.githubusercontent.com/3238878/36350788-e73143e2-1495-11e8-8034-99be5a508227.png)

Now

![image](https://user-images.githubusercontent.com/3238878/36350792-f4f36a46-1495-11e8-87a0-63625d0cc9bf.png)


