### PR TITLE
Add the ability to have trailing forward slashes

### DIFF
--- a/Sources/HaCWebsiteLib/routes.swift
+++ b/Sources/HaCWebsiteLib/routes.swift
@@ -34,14 +34,14 @@ func getWebsiteRouter() -> Router {
   router.post("/api/add_event", handler: EventApiController.handler)
 
   router.get("/", handler: LandingPageController.handler)
-  router.get("/constitution", handler: ConstitutionController.handler)
+  router.get("/constitution?", handler: ConstitutionController.handler)
 
   /// Custom event pages
   router.get("/events/2017/gamegig3000", handler: HackathonController.handler(hackathon: GameGig2017()))
 
   // MARK: Features in progress
   router.get("/beta/landing-update-feed", handler: LandingUpdateFeedController.handler)
-  router.get("/workshops", handler: WorkshopsController.handler)
+  router.get("/workshops?", handler: WorkshopsController.handler)
   router.get("/workshops/:workshopId", handler: WorkshopsController.workshopHandler)
   router.get("/workshops/update", middleware: CredentialsServer.credentials)
   router.get("/workshops/update", handler: WorkshopsController.workshopUpdateHandler)


### PR DESCRIPTION
Fixes #244.

Originally "https://hackersatcambridge.com/workshops/" would 404 - looking on the Kitura Router documentation I found that it was matching the exact "/workshops" string used in the routes.swift file. To amend this I added the question marks. Changed the "constitution" link at the same time. 

[Kitura Custom Path Documentation ](http://www.kitura.io/en/resources/tutorials/pathsyntax.html)