### PR TITLE
Change CDN provider for Workshops

### DIFF
--- a/Sources/HaCWebsiteLib/Models/Workshop+init.swift
+++ b/Sources/HaCWebsiteLib/Models/Workshop+init.swift
@@ -115,8 +115,7 @@ private struct WorkshopBuilder {
   }
 
   private func repoUrl(origin: String, relativePath: String) throws -> URL {
-    let urlString = "\(origin)hackersatcambridge/workshop-\(workshopId)/\(relativePath)"
-
+    let urlString = "\(origin)hackersatcambridge/workshop-\(workshopId)@\(relativePath)"
     if let url = URL(string: urlString) {
       return url
     } else {
@@ -125,7 +124,7 @@ private struct WorkshopBuilder {
   }
 
   func fileServingUrl(relativePath: String) throws -> URL {
-    return try repoUrl(origin: "https://rawgit.com/", relativePath: "\(commitSha)\(relativePath)")
+    return try repoUrl(origin: "https://cdn.jsdelivr.net/gh/", relativePath: "\(commitSha)\(relativePath)")
   }
 
   func remoteRepoUrl(relativePath: String) throws -> URL {

--- a/Sources/HaCWebsiteLib/Models/Workshop+init.swift
+++ b/Sources/HaCWebsiteLib/Models/Workshop+init.swift
@@ -115,7 +115,7 @@ private struct WorkshopBuilder {
   }
 
   private func repoUrl(origin: String, relativePath: String) throws -> URL {
-    let urlString = "\(origin)hackersatcambridge/workshop-\(workshopId)@\(relativePath)"
+    let urlString = "\(origin)hackersatcambridge/workshop-\(workshopId)\(relativePath)"
     if let url = URL(string: urlString) {
       return url
     } else {
@@ -124,11 +124,11 @@ private struct WorkshopBuilder {
   }
 
   func fileServingUrl(relativePath: String) throws -> URL {
-    return try repoUrl(origin: "https://cdn.jsdelivr.net/gh/", relativePath: "\(commitSha)\(relativePath)")
+    return try repoUrl(origin: "https://cdn.jsdelivr.net/gh/", relativePath: "@\(commitSha)\(relativePath)")
   }
 
   func remoteRepoUrl(relativePath: String) throws -> URL {
-    return try repoUrl(origin: "https://github.com/", relativePath: "tree/master\(relativePath)");
+    return try repoUrl(origin: "https://github.com/", relativePath: "/tree/master\(relativePath)");
   }
 
   /// Return the CDN url of the foreground of the promotional image

--- a/Tests/HaCWebsiteLibTests/WorkshopTests.swift
+++ b/Tests/HaCWebsiteLibTests/WorkshopTests.swift
@@ -20,8 +20,7 @@ class WorkshopTests: HaCWebsiteLibTestCase {
     XCTAssertEqual(workshop.license, "MIT")
 
     XCTAssert(workshop.notes.raw.contains("The main source of the workshop content."))
-
-    XCTAssertEqual(workshop.promoImageForeground, "https://rawgit.com/hackersatcambridge/workshop-passing-example/abcde/.hac_workshop/promo_images/fg.png")
+    XCTAssertEqual(workshop.promoImageForeground, "https://cdn.jsdelivr.net/gh/hackersatcambridge/workshop-passing-example@abcde/.hac_workshop/promo_images/fg.png")
     XCTAssertEqual(workshop.promoImageBackground, Background.color("#fffeee"))
 
     XCTAssertEqual(workshop.description.raw, "This workshop will take you through the basics of x. \nWe'll talk about how to foo and show you how, with a little work, you can bar your baz.")


### PR DESCRIPTION
Fixes #272  #261 .

Changing the CDN provider from Rawgit (which is now closing down) to JsDelivr 
