### PR TITLE
Update for new Vapor Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,5 @@ As the container shares source files with your project directory, any source fil
 ## Documentation
 
 Documentation on further features can be found in the [`/Docs`](/Docs) folder.
+
+Now using [Vapor Reverted Verison](https://github.com/patricoferris/heroku-buildpack.git) in Heroku.


### PR DESCRIPTION
Fix Heroku buildpack problem that was caused by new version of vapor buildpack which removed the `.build` folder. Now using forked version on @patricoferris github account.