### PR TITLE
Add initial about page

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/vapor/bits.git",
         "state": {
           "branch": null,
-          "revision": "c32f5e6ae2007dccd21a92b7e33eba842dd80d2f",
-          "version": "1.1.0"
+          "revision": "03079476b04139a8b744ad96f975176df5ae12bc",
+          "version": "1.1.1"
         }
       },
       {
@@ -29,21 +29,12 @@
         }
       },
       {
-        "package": "Console",
-        "repositoryURL": "https://github.com/vapor/console.git",
-        "state": {
-          "branch": null,
-          "revision": "11c0694857d1be6c7b8b30d8db8b1162b73f2a2b",
-          "version": "2.2.0"
-        }
-      },
-      {
         "package": "Core",
         "repositoryURL": "https://github.com/vapor/core.git",
         "state": {
           "branch": null,
-          "revision": "b8330808f4f6b69941961afe8ad6b015562f7b7c",
-          "version": "2.1.2"
+          "revision": "aa15871311b497a24a7f0e96b1ae6865dd600818",
+          "version": "2.2.1"
         }
       },
       {
@@ -56,30 +47,12 @@
         }
       },
       {
-        "package": "Crypto",
-        "repositoryURL": "https://github.com/vapor/crypto.git",
-        "state": {
-          "branch": null,
-          "revision": "bf4470b9da79024aab79c85de80374f6c29e3864",
-          "version": "2.1.1"
-        }
-      },
-      {
         "package": "Cryptor",
         "repositoryURL": "https://github.com/IBM-Swift/BlueCryptor.git",
         "state": {
           "branch": null,
-          "revision": "16f9c7ddcbe11bbd32106a791ebef2108a4e9183",
-          "version": "0.8.21"
-        }
-      },
-      {
-        "package": "CTLS",
-        "repositoryURL": "https://github.com/vapor/ctls.git",
-        "state": {
-          "branch": null,
-          "revision": "fddec6a4643d6e85b6bb6dc54b1b5cdbabd395d2",
-          "version": "1.1.2"
+          "revision": "de20ec9af166d779a08c16f05146f4b9124478d0",
+          "version": "0.8.27"
         }
       },
       {
@@ -96,17 +69,8 @@
         "repositoryURL": "https://github.com/vapor/debugging.git",
         "state": {
           "branch": null,
-          "revision": "49c5e8f0a7cb5456a8f7c72c6cd9f1553e5885a8",
-          "version": "1.1.0"
-        }
-      },
-      {
-        "package": "Engine",
-        "repositoryURL": "https://github.com/vapor/engine.git",
-        "state": {
-          "branch": null,
-          "revision": "decf702d774ac630dfe0441ff76b4bb68257b77a",
-          "version": "2.2.1"
+          "revision": "fc5a27d6eb236141dc24e5f14eedaa2e035ae7b3",
+          "version": "1.1.1"
         }
       },
       {
@@ -123,8 +87,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/HeliumLogger.git",
         "state": {
           "branch": null,
-          "revision": "2afeb4c02f5a48a7fbd081fe8607b91eeebd7ecb",
-          "version": "1.7.1"
+          "revision": "e38a5db514f384062262820acbdabdc883f64d7a",
+          "version": "1.7.3"
         }
       },
       {
@@ -137,21 +101,12 @@
         }
       },
       {
-        "package": "JSON",
-        "repositoryURL": "https://github.com/vapor/json.git",
-        "state": {
-          "branch": null,
-          "revision": "65416e9902cea47d820274dba296a24b057261d3",
-          "version": "2.0.0"
-        }
-      },
-      {
         "package": "Kitura",
         "repositoryURL": "https://github.com/IBM-Swift/Kitura.git",
         "state": {
           "branch": null,
-          "revision": "744a8fbc25a94f598d77662fd71eaa25d789c3fe",
-          "version": "2.0.0"
+          "revision": "72eca948ed94aacb8aea9002a603155a936b213c",
+          "version": "2.0.4"
         }
       },
       {
@@ -159,8 +114,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/Kitura-Credentials.git",
         "state": {
           "branch": null,
-          "revision": "0d67b58bd62df6094d44f3dfdc2a1d7d85f2e3ce",
-          "version": "2.0.0"
+          "revision": "46a080545bf369af0963d5e9013af55d3cbd386d",
+          "version": "2.0.2"
         }
       },
       {
@@ -168,8 +123,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/Kitura-CredentialsHTTP.git",
         "state": {
           "branch": null,
-          "revision": "4473713432329cdedb7c15acf71f0c62e937702c",
-          "version": "2.0.0"
+          "revision": "953c618037b297548325a293097446cf193beb22",
+          "version": "2.0.1"
         }
       },
       {
@@ -195,8 +150,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/Kitura-TemplateEngine.git",
         "state": {
           "branch": null,
-          "revision": "8e75a213bf4dd7b5effd03848335e344535969aa",
-          "version": "1.7.2"
+          "revision": "d43155da4dadd91c1d34d76e317571dc54655594",
+          "version": "1.7.4"
         }
       },
       {
@@ -204,8 +159,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/Kitura-Compression.git",
         "state": {
           "branch": null,
-          "revision": "1cf4aaba3a5a5fac8a1209175128c99be3916b45",
-          "version": "2.0.0"
+          "revision": "a305db3a4f2762ec3dbabf3fa497eb43d8f6fb74",
+          "version": "2.0.1"
         }
       },
       {
@@ -213,8 +168,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/KituraContracts.git",
         "state": {
           "branch": null,
-          "revision": "60ad79cfffeeb9693f53dd68067783d4fde5dc4d",
-          "version": "0.0.14"
+          "revision": "9d3e5b8cb8d2cb5cd32936d094218d954beeed7d",
+          "version": "0.0.24"
         }
       },
       {
@@ -231,8 +186,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/LoggerAPI.git",
         "state": {
           "branch": null,
-          "revision": "6b62fe66da9b8794d6581e5c341710eea3173cd4",
-          "version": "1.7.1"
+          "revision": "5041f2673aa75d6e973d9b6bd3956bc5068387c8",
+          "version": "1.7.3"
         }
       },
       {
@@ -240,8 +195,8 @@
         "repositoryURL": "https://github.com/vapor/node.git",
         "state": {
           "branch": null,
-          "revision": "642f357d08ec5aa335ae2e3c4633c72da7b5a0c4",
-          "version": "2.1.1"
+          "revision": "607aa595081da496f0f04a5c0cffd976e81d2e4e",
+          "version": "2.1.5"
         }
       },
       {
@@ -258,8 +213,8 @@
         "repositoryURL": "https://github.com/vapor-community/postgresql.git",
         "state": {
           "branch": null,
-          "revision": "cfbfa12c148fd2b44e6777d4ed2f57ca597e06e7",
-          "version": "2.1.0"
+          "revision": "1d23662a0b1b6b4689319607bb8d22daa57e5fca",
+          "version": "2.1.2"
         }
       },
       {
@@ -290,21 +245,12 @@
         }
       },
       {
-        "package": "Routing",
-        "repositoryURL": "https://github.com/vapor/routing.git",
-        "state": {
-          "branch": null,
-          "revision": "cb9d78aca2540c1a6b45b0ab43e5b0c50f29d216",
-          "version": "2.2.0"
-        }
-      },
-      {
         "package": "Signals",
         "repositoryURL": "https://github.com/IBM-Swift/BlueSignals.git",
         "state": {
           "branch": null,
-          "revision": "0fab5a9f166e96f17bb9646dc56cd22a6f3c3757",
-          "version": "0.9.50"
+          "revision": "d00d066869deec7b42a2ac3bd93f8df6753cdd2d",
+          "version": "0.9.52"
         }
       },
       {
@@ -312,17 +258,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/BlueSocket.git",
         "state": {
           "branch": null,
-          "revision": "00b126a2c19520bbf51cd26e8c0cc41dacbc5a05",
-          "version": "0.12.76"
-        }
-      },
-      {
-        "package": "Sockets",
-        "repositoryURL": "https://github.com/vapor/sockets.git",
-        "state": {
-          "branch": null,
-          "revision": "70d14c0e223257176f5ef69a595f7cad5de7a88b",
-          "version": "2.2.1"
+          "revision": "26c8f4e4e3000421a0c97aaf0c7b5e9aa5475222",
+          "version": "0.12.94"
         }
       },
       {
@@ -339,8 +276,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/BlueSSLService.git",
         "state": {
           "branch": null,
-          "revision": "7adf7cacc447d447df5dcc3058cabd402177c5aa",
-          "version": "0.12.64"
+          "revision": "3a87b64a97fb8e923f52f2a68e31e7bd4fc46b42",
+          "version": "0.12.84"
         }
       },
       {
@@ -357,17 +294,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/SwiftyJSON.git",
         "state": {
           "branch": null,
-          "revision": "1190845cf7d25a5c8ea7653fe03dcdd39a082056",
-          "version": "17.0.0"
-        }
-      },
-      {
-        "package": "TLS",
-        "repositoryURL": "https://github.com/vapor/tls.git",
-        "state": {
-          "branch": null,
-          "revision": "6c6eedb6761cddc6b6c87142a27eec13fa1701ec",
-          "version": "2.1.1"
+          "revision": "693d2d28fe2f91aedf02c3754baade625fd97c46",
+          "version": "17.0.2"
         }
       },
       {

--- a/Sources/HaCWebsiteLib/Controllers/AboutController.swift
+++ b/Sources/HaCWebsiteLib/Controllers/AboutController.swift
@@ -1,0 +1,32 @@
+import Kitura
+import HaCTML
+import LoggerAPI
+import HeliumLogger
+import DotEnv
+import SwiftyJSON
+
+struct AboutController {
+  static var handler: RouterHandler = { request, response, next in
+    var content: Node {
+      return El.Div[Attr.className => "LandingAbout__text", 
+                    Attr.style => ["margin": "0% 15%"]
+              ].containing(
+              El.H1[Attr.className => "LandingAbout__subtitle Text--sectionHeading"].containing("About Hacker's at Cambridge"),
+              Markdown("""
+                Hacker's at Cambridge are a technology society aimed at promoting a culture of creators and innovators in Cambridge. We organise workshops, events and talks for any student in Cambridge who wants to take part, fostering a collaborative culture.
+              
+                The main committee members include Timothy Lazarus, Eliot Lim, Mukul Rathi, Hari Prasad and Patrick Ferris.
+              """))
+    }
+
+    try response.send(
+      Page(
+        title: "About Hacker's at Cambridge",
+        content: Fragment(
+          BackBar(backLinkText: "Home", backLinkURL: "/"),
+          content
+        )
+      ).node.render()
+    ).end()
+  }
+}

--- a/Sources/HaCWebsiteLib/Views/LandingPage/LandingPage.swift
+++ b/Sources/HaCWebsiteLib/Views/LandingPage/LandingPage.swift
@@ -100,7 +100,13 @@ struct LandingPage: Nodeable {
                 Don't let the name scare you, we aren't the kind of hackers that try our best to get around complex security systems. We are simply an enthusiastic group of people who love technology.
 
                 At HaC it’s our mission to empower everyone to build whatever technology project they want. Whether you are a complete beginner or a seasoned pro, we're here to help you develop and share your tech skills.
-              """)
+              """),
+              El.A[
+                Attr.href => "/about",
+                Attr.className => "BigButton"
+              ].containing(
+                "About us"
+              )
             )
           ),
           El.Article[Attr.className => "LandingAbout__section"].containing(

--- a/Sources/HaCWebsiteLib/routes.swift
+++ b/Sources/HaCWebsiteLib/routes.swift
@@ -41,6 +41,9 @@ func getWebsiteRouter() -> Router {
   /// Custom event pages
   router.get("/events/2017/gamegig3000", handler: HackathonController.handler(hackathon: GameGig2017()))
 
+  // About section of the website
+  router.get("/about", handler: AboutController.handler)
+
   // MARK: Features in progress
   router.get("/beta/landing-update-feed", handler: LandingUpdateFeedController.handler)
   router.get("/workshops", handler: WorkshopsController.handler)


### PR DESCRIPTION
**DO NOT MERGE UNTIL EVERYONE HAS GIVEN PERMISSION TO HAVE THEIR NAMES ON THE SITE**

Adding about page primarily so we can hand over the ownership of Slack, hence it contains only the bare minimum information about the society (we can expand on this later in the year) but also our names.

Now the landing page looks like:
![image](https://user-images.githubusercontent.com/20166594/49940339-8528b600-fedf-11e8-8be0-9981ea1ed58c.png)

And the 'about us' button redirects to '/about'
![image](https://user-images.githubusercontent.com/20166594/49940425-b2756400-fedf-11e8-8879-aee5feac2e87.png)



